### PR TITLE
CLI: banner description wraps at the layout width, colored log prefixes

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -33,6 +33,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["packages/cli/scripts/preview/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noControlCharactersInRegex": "off"
+          }
+        }
+      }
     }
   ],
   "javascript": {

--- a/packages/cli/scripts/preview/.gitignore
+++ b/packages/cli/scripts/preview/.gitignore
@@ -1,0 +1,4 @@
+out/
+before-pkg/
+*.log
+scenarios.json

--- a/packages/cli/scripts/preview/README.md
+++ b/packages/cli/scripts/preview/README.md
@@ -1,0 +1,19 @@
+# Preview recordings
+
+Records the CLI's scenarios under a real pseudo-terminal (100×50, one at 60
+columns) for two builds — a published version and this branch's `dist` — and
+renders the final terminal screens as HTML for a before/after review page.
+
+```sh
+pnpm build                                                  # this branch's bundle
+(cd scripts/preview/before-pkg && npm pack @millionsend/cli@<version> && tar xzf *.tgz)
+SKIP_ENV_VALIDATION=1 pnpm exec tsx scripts/preview/capture.mjs before after   # ~25 min
+node scripts/preview/build-page.mjs                         # → out/cli-before-after.html
+```
+
+`capture.mjs` boots the fake Resend account and a real API on PGlite (the
+same helpers the e2e uses), so nothing here touches a real account.
+`pty-run.py` runs the bundle under a pty with a fixed window size and can
+answer a prompt once (`--enter-on TEXT`); `vt.mjs` replays the raw output
+through a small terminal emulator so in-place redraws collapse to the screen a
+user ends up seeing; `ansi-to-html.mjs` turns that screen into `<pre>` markup.

--- a/packages/cli/scripts/preview/ansi-to-html.mjs
+++ b/packages/cli/scripts/preview/ansi-to-html.mjs
@@ -1,0 +1,51 @@
+// Usage: node ansi-to-html.mjs in.txt out.html
+// A vt.mjs screen (text with inline SGR) → <pre class="term"> fragment with one
+// <span class="…"> per styled run. Classes: bold, dim, italic, underline,
+// inverse, fg-<n> and bg-<n> for the 16 ANSI colors (fg-32, fg-97, fg-90 …),
+// fg-38-5-<n> / fg-38-2-<r>-<g>-<b> for extended colors. HTML is escaped.
+import { readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { applySgr, DEFAULT } from "./sgr.mjs";
+
+const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const classes = (s) =>
+  [
+    s.bold && "bold",
+    s.dim && "dim",
+    s.italic && "italic",
+    s.underline && "underline",
+    s.inverse && "inverse",
+    s.fg !== null && `fg-${s.fg.replace(/;/g, "-")}`,
+    s.bg !== null && `bg-${s.bg.replace(/;/g, "-")}`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+export function toHtml(text) {
+  let state = { ...DEFAULT };
+  let open = "";
+  let out = "";
+  for (const part of text.split(/(\x1b\[[0-9;]*m)/)) {
+    const m = /^\x1b\[([0-9;]*)m$/.exec(part);
+    if (m) {
+      state = applySgr(state, m[1]);
+      continue;
+    }
+    if (part === "") continue;
+    const cls = classes(state);
+    if (cls !== open) {
+      if (open !== "") out += "</span>";
+      if (cls !== "") out += `<span class="${cls}">`;
+      open = cls;
+    }
+    out += esc(part);
+  }
+  if (open !== "") out += "</span>";
+  return `<pre class="term">${out}\n</pre>\n`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [, , input, output] = process.argv;
+  writeFileSync(output, toHtml(readFileSync(input, "utf8").replace(/\n$/, "")));
+}

--- a/packages/cli/scripts/preview/build-page.mjs
+++ b/packages/cli/scripts/preview/build-page.mjs
@@ -1,0 +1,229 @@
+// Assembles the before/after review page from scenarios.json and the rendered screens.
+// Usage: node build-page.mjs  → out/cli-before-after.html
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const HERE = new URL(".", import.meta.url).pathname;
+const scenarios = JSON.parse(readFileSync(join(HERE, "scenarios.json"), "utf8"));
+
+const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const stats = (htmlPath) => {
+  const txt = readFileSync(join(HERE, htmlPath.replace(/\.html$/, ".txt")), "utf8")
+    .replace(/\x1b\[[0-9;]*m/g, "")
+    .replace(/\n$/, "");
+  const lines = txt.split("\n");
+  const widest = Math.max(...lines.map((l) => [...l].length));
+  return { lines: lines.length, widest };
+};
+const screen = (htmlPath) => readFileSync(join(HERE, htmlPath), "utf8").trim();
+
+const BUILDS = [
+  { key: "before", chip: "0.1.1 · published", label: "Before" },
+  { key: "after", chip: "next · this branch", label: "After" },
+];
+
+const windows = (s) =>
+  BUILDS.map((b) => {
+    const st = stats(s[b.key].html);
+    return `
+      <section class="win" data-build="${b.key}" aria-label="${b.label}: ${esc(s.title)}">
+        <div class="bar">
+          <span class="dots" aria-hidden="true"><i></i><i></i><i></i></span>
+          <span class="bar-title">millionsend — ${s[b.key].cols}×50</span>
+          <span class="chip chip-${b.key}">${b.chip}</span>
+        </div>
+        <div class="screen" style="--cols:${s[b.key].cols}" tabindex="0">${screen(s[b.key].html)}</div>
+        <div class="foot"><span>${st.lines} lines</span><span>widest line ${st.widest} cells</span></div>
+      </section>`;
+  }).join("");
+
+const railItems = scenarios
+  .map((s) => {
+    const b = stats(s.before.html);
+    const a = stats(s.after.html);
+    return `<button class="rail-item" role="tab" data-id="${s.id}" aria-selected="false">
+      <span class="rail-title">${esc(s.title)}</span>
+      <span class="rail-meta"><span>${b.lines}</span><span class="arrow">→</span><span>${a.lines}</span> lines</span>
+    </button>`;
+  })
+  .join("");
+
+const scenes = scenarios
+  .map(
+    (s) => `
+    <article class="scene" data-id="${s.id}" hidden>
+      <div class="scene-head">
+        <h2>${esc(s.title)}</h2>
+        <pre class="cmd">${s.command
+          .split("\n")
+          .map((c) => `<span class="prompt">$</span> ${esc(c)}`)
+          .join("\n")}</pre>
+        <p class="notes">${esc(s.notes)}</p>
+      </div>
+      <div class="stage">${windows(s)}</div>
+    </article>`,
+  )
+  .join("");
+
+const page = `<title>Migrate CLI Before and After</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600&family=JetBrains+Mono:wght@400;700&display=swap">
+<style>
+  :root {
+    color-scheme: dark;
+    --void: #0a0a0a; --panel: #0c0c0d; --panel-2: #121214; --line: #1f1f22; --line-2: #2a2a2e;
+    --bone: #f4f1ea; --ink-2: #b9b5ac; --steel: #7f8791;
+    --ui: "Geist", system-ui, -apple-system, "Segoe UI", sans-serif;
+    --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+    --term-bg: #0c0c0d; --term-fg: #f4f1ea; --term-dim: #7f8791; --term-bright: #ffffff;
+    --t-green: #4ade80; --t-yellow: #facc15; --t-red: #f87171; --t-cyan: #67e8f9; --t-magenta: #e879f9; --t-blue: #93c5fd;
+  }
+  @media (prefers-color-scheme: light) {
+    :root:not([data-theme="dark"]) {
+      color-scheme: light;
+      --void: #ecebe6; --panel: #f6f5f1; --panel-2: #ffffff; --line: #d9d7d0; --line-2: #c7c5bd;
+      --bone: #0a0a0a; --ink-2: #4a4c50; --steel: #6b737d;
+    }
+  }
+  :root[data-theme="light"] {
+    color-scheme: light;
+    --void: #ecebe6; --panel: #f6f5f1; --panel-2: #ffffff; --line: #d9d7d0; --line-2: #c7c5bd;
+    --bone: #0a0a0a; --ink-2: #4a4c50; --steel: #6b737d;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--void); color: var(--bone); font-family: var(--ui); font-size: 14px; line-height: 1.5; -webkit-font-smoothing: antialiased; }
+  .top { padding: 28px 32px 20px; border-bottom: 1px solid var(--line); display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 12px 32px; align-items: end; }
+  h1 { margin: 0; font-size: 22px; font-weight: 500; letter-spacing: -0.01em; text-wrap: balance; }
+  h1 code, .lede code { font-family: var(--mono); font-weight: 400; font-size: 0.92em; }
+  .lede { margin: 6px 0 0; max-width: 68ch; color: var(--ink-2); }
+  .legend { display: flex; gap: 18px; font-family: var(--mono); font-size: 12px; color: var(--steel); white-space: nowrap; }
+  .legend b { font-weight: 500; }
+  .body { display: grid; grid-template-columns: 248px minmax(0, 1fr); min-height: calc(100vh - 110px); }
+  .rail { border-right: 1px solid var(--line); padding: 16px 12px; display: flex; flex-direction: column; gap: 2px; position: sticky; top: 0; align-self: start; max-height: 100vh; overflow: auto; }
+  .rail-label { font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--steel); padding: 4px 10px 8px; }
+  .rail-item { all: unset; cursor: pointer; display: grid; gap: 2px; padding: 9px 10px; border-radius: 8px; border-left: 2px solid transparent; }
+  .rail-item:hover { background: var(--panel-2); }
+  .rail-item:focus-visible { outline: 2px solid var(--steel); outline-offset: 2px; }
+  .rail-item[aria-selected="true"] { background: var(--panel-2); border-left-color: var(--steel); }
+  .rail-title { font-weight: 500; }
+  .rail-meta { font-family: var(--mono); font-size: 11.5px; color: var(--steel); font-variant-numeric: tabular-nums; display: flex; gap: 5px; }
+  .rail-meta .arrow { color: var(--line-2); }
+  main { padding: 20px 28px 48px; min-width: 0; }
+  .scene-head { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 6px 24px; align-items: start; margin-bottom: 16px; }
+  .scene-head h2 { margin: 0; font-size: 18px; font-weight: 500; letter-spacing: -0.01em; }
+  .cmd { grid-column: 1; margin: 0; font-family: var(--mono); font-size: 12.5px; color: var(--ink-2); white-space: pre-wrap; word-break: break-word; }
+  .cmd .prompt { color: var(--steel); }
+  .notes { grid-column: 1; margin: 0; color: var(--ink-2); max-width: 78ch; }
+  .view { grid-column: 2; grid-row: 1 / span 3; display: inline-flex; border: 1px solid var(--line); border-radius: 8px; padding: 3px; gap: 2px; background: var(--panel); align-self: start; }
+  .view button { all: unset; cursor: pointer; padding: 5px 12px; border-radius: 6px; font-size: 13px; color: var(--ink-2); white-space: nowrap; }
+  .view button:focus-visible { outline: 2px solid var(--steel); }
+  .view button[aria-pressed="true"] { background: var(--panel-2); color: var(--bone); box-shadow: inset 0 0 0 1px var(--line-2); }
+  .view kbd { font-family: var(--mono); font-size: 10.5px; color: var(--steel); margin-left: 6px; }
+  .stage { display: grid; gap: 18px; grid-template-columns: minmax(0, 1fr); }
+  .stage[data-view="side"] { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .stage[data-view="before"] .win[data-build="after"], .stage[data-view="after"] .win[data-build="before"] { display: none; }
+  .win { min-width: 0; background: var(--term-bg); border: 1px solid var(--line); border-radius: 10px; overflow: hidden; display: grid; grid-template-rows: auto minmax(0, 1fr) auto; }
+  .bar { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; padding: 9px 12px; border-bottom: 1px solid #1f1f22; background: #0a0a0a; color: var(--term-dim); font-family: var(--mono); font-size: 11.5px; }
+  .dots { display: inline-flex; gap: 6px; }
+  .dots i { width: 10px; height: 10px; border-radius: 50%; background: #1f1f22; border: 1px solid #2a2a2e; }
+  .bar-title { text-align: center; }
+  .chip { justify-self: end; padding: 2px 8px; border-radius: 999px; border: 1px solid #2a2a2e; font-size: 11px; color: #b9b5ac; }
+  .chip-after { border-color: var(--steel); color: #f4f1ea; }
+  .screen { overflow: auto; padding: 16px 18px 18px; max-height: 72vh; scrollbar-color: #2a2a2e #0c0c0d; }
+  .screen:focus-visible { outline: 2px solid var(--steel); outline-offset: -2px; }
+  .term { margin: 0; font-family: var(--mono); font-size: 12.5px; line-height: 1.5; color: var(--term-fg); min-width: calc(var(--cols) * 1ch); tab-size: 8; }
+  .foot { display: flex; gap: 16px; padding: 7px 14px; border-top: 1px solid #1f1f22; font-family: var(--mono); font-size: 11px; color: var(--term-dim); font-variant-numeric: tabular-nums; }
+  .term .bold { font-weight: 700; color: var(--term-bright); }
+  .term .dim, .term .fg-90 { color: var(--term-dim); }
+  .term .fg-97 { color: var(--term-bright); }
+  .term .fg-31, .term .fg-91 { color: var(--t-red); }
+  .term .fg-32, .term .fg-92 { color: var(--t-green); }
+  .term .fg-33, .term .fg-93 { color: var(--t-yellow); }
+  .term .fg-34, .term .fg-94 { color: var(--t-blue); }
+  .term .fg-35, .term .fg-95 { color: var(--t-magenta); }
+  .term .fg-36, .term .fg-96 { color: var(--t-cyan); }
+  .term .fg-37 { color: var(--term-fg); }
+  .term .bold.fg-32 { color: var(--t-green); }
+  .term .bold.fg-33 { color: var(--t-yellow); }
+  .term .bold.fg-31 { color: var(--t-red); }
+  .term .dim.bold { color: var(--term-dim); }
+  @media (max-width: 1180px) { .stage[data-view="side"] { grid-template-columns: minmax(0, 1fr); } }
+  @media (max-width: 860px) {
+    .body { grid-template-columns: minmax(0, 1fr); }
+    .rail { position: static; max-height: none; border-right: 0; border-bottom: 1px solid var(--line); flex-direction: row; flex-wrap: wrap; }
+    .rail-label { width: 100%; }
+    .top, .scene-head { grid-template-columns: minmax(0, 1fr); }
+    .view { grid-column: 1; grid-row: auto; }
+    main { padding: 16px; }
+  }
+  @media (prefers-reduced-motion: no-preference) { .rail-item, .view button { transition: background-color 120ms ease, color 120ms ease; } }
+</style>
+
+<header class="top">
+  <div>
+    <h1>The migrate CLI, before and after</h1>
+    <p class="lede">Nine recordings of <code>@millionsend/cli</code> against the same seeded Resend account and a fresh MillionSend instance, captured under a real pseudo-terminal at 100×50 (one at 60 columns). Left, 0.1.1 as published; right, the restyled build on this branch. Screens are the terminal's final state after every in-place redraw.</p>
+  </div>
+  <div class="legend" aria-label="Terminal colors"><span><b style="color:var(--t-green)">✓</b> done</span><span><b style="color:var(--t-cyan)">⟳</b> running</span><span><b style="color:var(--t-magenta)">!</b> manual</span><span><b style="color:var(--t-yellow)">~</b> update</span><span><b style="color:var(--t-red)">✗</b> failed</span></div>
+</header>
+<div class="body">
+  <nav class="rail" role="tablist" aria-label="Scenarios">
+    <div class="rail-label">Scenarios</div>
+    ${railItems}
+  </nav>
+  <main>
+    <div class="view" role="group" aria-label="View">
+      <button type="button" data-view="before" aria-pressed="false">Before<kbd>1</kbd></button>
+      <button type="button" data-view="after" aria-pressed="false">After<kbd>2</kbd></button>
+      <button type="button" data-view="side" aria-pressed="false">Side by side<kbd>3</kbd></button>
+    </div>
+    ${scenes}
+  </main>
+</div>
+<script>
+  (() => {
+    const ids = ${JSON.stringify(scenarios.map((s) => s.id))};
+    const rail = [...document.querySelectorAll(".rail-item")];
+    const scenes = [...document.querySelectorAll(".scene")];
+    const viewButtons = [...document.querySelectorAll(".view button")];
+    const viewBox = document.querySelector(".view");
+    let view = null;
+    try { view = localStorage.getItem("migrate-preview-view"); } catch {}
+    if (!["before", "after", "side"].includes(view)) view = window.innerWidth >= 1180 ? "side" : "after";
+    let current = "migrate";
+    try { current = localStorage.getItem("migrate-preview-scene") || current; } catch {}
+    if (!ids.includes(current)) current = ids[0];
+    const applyView = () => {
+      for (const b of viewButtons) b.setAttribute("aria-pressed", String(b.dataset.view === view));
+      for (const stage of document.querySelectorAll(".stage")) stage.dataset.view = view;
+      try { localStorage.setItem("migrate-preview-view", view); } catch {}
+    };
+    const show = (id) => {
+      current = id;
+      for (const s of scenes) s.hidden = s.dataset.id !== id;
+      for (const r of rail) r.setAttribute("aria-selected", String(r.dataset.id === id));
+      const active = scenes.find((s) => s.dataset.id === id);
+      if (active) active.querySelector(".scene-head").before(viewBox);
+      try { localStorage.setItem("migrate-preview-scene", id); } catch {}
+    };
+    for (const r of rail) r.addEventListener("click", () => show(r.dataset.id));
+    for (const b of viewButtons) b.addEventListener("click", () => { view = b.dataset.view; applyView(); });
+    document.addEventListener("keydown", (e) => {
+      if (e.target instanceof HTMLElement && /input|textarea/i.test(e.target.tagName)) return;
+      const i = ids.indexOf(current);
+      if (e.key === "ArrowRight" || e.key === "j") show(ids[(i + 1) % ids.length]);
+      else if (e.key === "ArrowLeft" || e.key === "k") show(ids[(i - 1 + ids.length) % ids.length]);
+      else if (e.key === "1") { view = "before"; applyView(); }
+      else if (e.key === "2") { view = "after"; applyView(); }
+      else if (e.key === "3") { view = "side"; applyView(); }
+      else return;
+      e.preventDefault();
+    });
+    applyView();
+    show(current);
+  })();
+</script>
+`;
+
+writeFileSync(join(HERE, "out", "cli-before-after.html"), page);
+console.log(`wrote ${join(HERE, "out", "cli-before-after.html")} (${page.length} bytes)`);

--- a/packages/cli/scripts/preview/capture.mjs
+++ b/packages/cli/scripts/preview/capture.mjs
@@ -1,0 +1,264 @@
+// Usage (from packages/cli so tsx resolves the workspace):
+//   SKIP_ENV_VALIDATION=1 pnpm exec tsx <PREVIEW>/capture.mjs [before|after]... [--only id,id]
+// Records every scenario for each build under a pty (pty-run.py) against a
+// fresh fake Resend + cloud + self-hosted API per build, then writes
+// out/<build>/<id>.{ansi,txt,html} and scenarios.json.
+import { spawn } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startFakeResend } from "../../test/helpers/fake-resend.ts";
+import { startLiveApi } from "../../test/helpers/live-api.ts";
+import { fakeId, realisticAccount } from "../../test/helpers/realistic-account.ts";
+import { toHtml } from "./ansi-to-html.mjs";
+import { screen } from "./vt.mjs";
+
+const HERE = new URL(".", import.meta.url).pathname;
+const OUT = join(HERE, "out");
+const PTY = join(HERE, "pty-run.py");
+const BUNDLE = {
+  before: join(HERE, "before-pkg/package/dist/index.js"),
+  after: join(HERE, "../../dist/index.js"),
+};
+// Prompts that wait for a keypress under a tty; Enter takes their defaults.
+const ENTER_ON = ["enter confirms", "Domain limit\r"];
+const MIGRATE = ["migrate", "--from", "resend", "--yes", "--rps", "10"];
+const BAD_KEY = "re_invalid_key_000000";
+
+const argv = process.argv.slice(2);
+const onlyIds = argv.includes("--only") ? argv[argv.indexOf("--only") + 1].split(",") : null;
+const builds = argv.filter((a) => a in BUNDLE);
+if (builds.length === 0) builds.push("before", "after");
+
+const freshCwd = (tag) => {
+  const cwd = mkdtempSync(join(tmpdir(), `millionsend-preview-${tag}-`));
+  writeFileSync(join(cwd, ".gitignore"), "node_modules\n");
+  return cwd;
+};
+
+const cwdCounter = { n: 0 };
+function makeEnv(fake, cloud, extra = {}) {
+  const env = {
+    ...process.env,
+    RESEND_API_KEY: fake.token,
+    MILLIONSEND_CLI_RESEND_URL: fake.url,
+    RESEND_BASE_URL: fake.url,
+    MILLIONSEND_API_KEY: cloud.apiKey,
+    MILLIONSEND_BASE_URL: cloud.baseUrl,
+  };
+  for (const k of ["NO_COLOR", "FORCE_COLOR", "COLUMNS", "LINES"]) delete env[k];
+  for (const [k, v] of Object.entries(extra)) {
+    if (v === undefined) delete env[k];
+    else env[k] = v;
+  }
+  return env;
+}
+
+function runPty({ bundle, args, cwd, env, cols = 100, rows = 50 }) {
+  const child = spawn(
+    "python3",
+    [
+      PTY,
+      String(cols),
+      String(rows),
+      ...ENTER_ON.flatMap((m) => ["--enter-on", m]),
+      "--",
+      process.execPath,
+      bundle,
+      ...args,
+    ],
+    { cwd, env, stdio: ["ignore", "pipe", "inherit"] },
+  );
+  const chunks = [];
+  child.stdout.on("data", (c) => chunks.push(c));
+  return new Promise((resolve) =>
+    child.on("close", (code) => resolve({ code, out: Buffer.concat(chunks) })),
+  );
+}
+
+const echo = (args) => Buffer.from(`$ millionsend ${args.join(" ")}\r\n`);
+
+/*
+ * Order matters: the cloud instance is shared for a build. Read-only
+ * scenarios first; migrate/status/rollback share a cwd; resume runs last
+ * because it leaves rows behind.
+ */
+const SCENARIOS = [
+  {
+    id: "help",
+    title: "Help",
+    args: ["--help"],
+    notes:
+      "Command grammar, flags and the trademark line; AFTER documents --color <mode> and FORCE_COLOR (no banner on --help in either build).",
+  },
+  {
+    id: "plan",
+    title: "Plan (read-only)",
+    args: ["migrate", "plan", "--from", "resend"],
+    notes:
+      "Connect lines, the read progress, the resource picker, and the plan table with manual items and the domain-cap warning.",
+  },
+  {
+    id: "narrow",
+    title: "Plan at 60 columns",
+    args: ["migrate", "plan", "--from", "resend"],
+    cols: 60,
+    notes: "The compact banner tier and how the plan wraps in a narrow terminal.",
+  },
+  {
+    id: "badkey",
+    title: "Rejected Resend key",
+    args: ["migrate", "plan", "--from", "resend"],
+    env: { RESEND_API_KEY: BAD_KEY },
+    notes: "The exit-1 message for a 401 from Resend, before anything is read.",
+  },
+  {
+    id: "selfhost",
+    title: "Self-hosted target",
+    args: [...MIGRATE, "--to-url", "SELF_URL", "--skip", "enrichment"],
+    self: true,
+    notes: "Neutral copy for a self-hosted instance: no plan name, no upgrade offer.",
+  },
+  {
+    id: "migrate",
+    title: "Full migration",
+    args: MIGRATE,
+    cwd: "shared",
+    notes:
+      "The whole run: prompts, applying progress at 10 req/s with enrichment, and the summary with the to-do list, id map and DNS records.",
+  },
+  {
+    id: "status",
+    title: "Status",
+    args: ["migrate", "status"],
+    cwd: "shared",
+    notes:
+      "What the saved state says after a completed run; AFTER adds the State heading and bold counts.",
+  },
+  {
+    id: "rollback",
+    title: "Rollback",
+    args: ["migrate", "rollback", "--yes"],
+    cwd: "shared",
+    notes:
+      "Deleting only what the tool created; the estimate line and the final note about updated rows.",
+  },
+  {
+    id: "resume",
+    title: "Interrupted and resumed",
+    args: MIGRATE,
+    resume: true,
+    notes:
+      "A 401 from Resend mid-enrichment exits 1 with the state saved; the same command again picks up where it stopped.",
+  },
+];
+
+const results = {};
+for (const build of builds) {
+  const bundle = BUNDLE[build];
+  console.log(`\n=== ${build}: ${bundle}`);
+  const [fake, cloud, self] = await Promise.all([
+    startFakeResend(realisticAccount()),
+    startLiveApi({ isCloud: true, appBaseUrl: "https://app.example.test", slug: "cloud" }),
+    // A self-hosted instance has APP_BASE_URL set: without it the API refuses
+    // the domains' tracking settings and the run exits 3 with two failed items.
+    startLiveApi({ isCloud: false, appBaseUrl: "https://mail.example.test", slug: "self" }),
+  ]);
+  const api = async (path, body) => {
+    const r = await fetch(`${cloud.baseUrl}${path}`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${cloud.apiKey}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!r.ok) throw new Error(`${path} → ${r.status} ${await r.text()}`);
+    return r.json();
+  };
+  // Same seed as the e2e: a verified sender, an unrelated domain, a topic that differs.
+  await api("/domains", { name: "example.com", region: "us-east-1" });
+  await cloud.db.execute("update domains set status = 'verified'");
+  await api("/domains", { name: "legacy.example.net", region: "us-east-1" });
+  await api("/topics", {
+    name: "Newsletter",
+    description: "Old description",
+    default_subscription: "opt_out",
+  });
+
+  const dir = join(OUT, build);
+  mkdirSync(dir, { recursive: true });
+  const shared = freshCwd(`${build}-shared`);
+  results[build] = {};
+
+  for (const s of SCENARIOS) {
+    if (onlyIds && !onlyIds.includes(s.id)) continue;
+    const started = Date.now();
+    const cwd = s.cwd === "shared" ? shared : freshCwd(`${build}-${s.id}-${cwdCounter.n++}`);
+    const env = makeEnv(
+      fake,
+      cloud,
+      s.self
+        ? { MILLIONSEND_API_KEY: self.apiKey, MILLIONSEND_BASE_URL: undefined, ...s.env }
+        : s.env,
+    );
+    const args = s.args.map((a) => (a === "SELF_URL" ? self.baseUrl : a));
+    const parts = [];
+    const codes = [];
+    if (s.resume) {
+      fake.injectOnce(`/contacts/${fakeId(5, 5)}`, {
+        status: 401,
+        body: { name: "invalid_api_key", message: "API key is invalid" },
+      });
+      const first = await runPty({ bundle, args, cwd, env });
+      parts.push(echo(args), first.out, Buffer.from("\r\n"));
+      codes.push(first.code);
+      const second = await runPty({ bundle, args, cwd, env });
+      parts.push(echo(args), second.out);
+      codes.push(second.code);
+    } else {
+      const run = await runPty({ bundle, args, cwd, env, cols: s.cols });
+      parts.push(run.out);
+      codes.push(run.code);
+    }
+    const ansi = Buffer.concat(parts);
+    writeFileSync(join(dir, `${s.id}.ansi`), ansi);
+    const txt = screen(ansi.toString("utf8"));
+    writeFileSync(join(dir, `${s.id}.txt`), `${txt}\n`);
+    writeFileSync(join(dir, `${s.id}.html`), toHtml(txt));
+    results[build][s.id] = {
+      codes,
+      bytes: ansi.length,
+      seconds: Math.round((Date.now() - started) / 1000),
+    };
+    console.log(
+      `${build}/${s.id}: exit ${codes.join(",")}, ${ansi.length} bytes, ${results[build][s.id].seconds}s`,
+    );
+  }
+  await Promise.all([fake.close(), cloud.stop(), self.stop()]);
+}
+
+const shown = (s) => {
+  const cmd = `millionsend ${s.args.map((a) => (a === "SELF_URL" ? "http://127.0.0.1:<port>" : a)).join(" ")}`;
+  const envPrefix = s.self
+    ? "MILLIONSEND_API_KEY=<self-hosted key> "
+    : s.env?.RESEND_API_KEY
+      ? `RESEND_API_KEY=${BAD_KEY} `
+      : "";
+  return s.resume ? `${cmd}\n${cmd}` : `${envPrefix}${cmd}`;
+};
+writeFileSync(
+  join(HERE, "scenarios.json"),
+  `${JSON.stringify(
+    SCENARIOS.map((s) => ({
+      id: s.id,
+      title: s.title,
+      command: shown(s),
+      notes: s.notes,
+      before: { html: `out/before/${s.id}.html`, cols: s.cols ?? 100 },
+      after: { html: `out/after/${s.id}.html`, cols: s.cols ?? 100 },
+    })),
+    null,
+    2,
+  )}\n`,
+);
+writeFileSync(join(OUT, "results.json"), `${JSON.stringify(results, null, 2)}\n`);
+console.log("\ndone");
+process.exit(0);

--- a/packages/cli/scripts/preview/pty-run.py
+++ b/packages/cli/scripts/preview/pty-run.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""pty-run.py <cols> <rows> [--enter-on TEXT]... -- cmd args...
+
+Runs cmd under a pty of the given size (TERM=xterm-256color), writes the raw
+transcript to stdout and exits with the child's code. Each --enter-on TEXT
+sends Enter to the child the first time TEXT shows up in its output, which is
+how a prompt that waits for a keypress gets answered with its default.
+macOS `script` needs a tty on its own stdin; this does not.
+"""
+import fcntl
+import os
+import pty
+import struct
+import sys
+import termios
+
+args = sys.argv[1:]
+cols, rows = int(args[0]), int(args[1])
+enter_on = []
+i = 2
+while args[i] != "--":
+    if args[i] != "--enter-on":
+        raise SystemExit(__doc__)
+    enter_on.append(args[i + 1].encode())
+    i += 2
+cmd = args[i + 1:]
+
+pid, fd = pty.fork()
+if pid == 0:
+    fcntl.ioctl(0, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+    os.environ["TERM"] = "xterm-256color"
+    os.execvp(cmd[0], cmd)
+
+out = sys.stdout.buffer
+tail = b""
+while True:
+    try:
+        data = os.read(fd, 65536)
+    except OSError:  # EIO once the slave side is closed
+        break
+    if not data:
+        break
+    out.write(data)
+    out.flush()
+    tail = (tail + data)[-8192:]
+    for marker in [m for m in enter_on if m in tail]:
+        enter_on.remove(marker)
+        os.write(fd, b"\r")
+
+_, status = os.waitpid(pid, 0)
+sys.exit(os.waitstatus_to_exitcode(status) if os.WIFEXITED(status) else 128 + os.WTERMSIG(status))

--- a/packages/cli/scripts/preview/sgr.mjs
+++ b/packages/cli/scripts/preview/sgr.mjs
@@ -1,0 +1,58 @@
+// SGR state shared by vt.mjs (screen → text with inline SGR) and ansi-to-html.mjs.
+
+export const DEFAULT = Object.freeze({
+  bold: false,
+  dim: false,
+  italic: false,
+  underline: false,
+  inverse: false,
+  fg: null,
+  bg: null,
+});
+
+/** Applies one `\x1b[...m` parameter list to a state; unknown codes are ignored. */
+export function applySgr(state, params) {
+  const codes = params === "" ? [0] : params.split(";").map(Number);
+  let s = { ...state };
+  for (let i = 0; i < codes.length; i++) {
+    const n = codes[i];
+    if (n === 0) s = { ...DEFAULT };
+    else if (n === 1) s.bold = true;
+    else if (n === 2) s.dim = true;
+    else if (n === 3) s.italic = true;
+    else if (n === 4) s.underline = true;
+    else if (n === 7) s.inverse = true;
+    else if (n === 22) {
+      s.bold = false;
+      s.dim = false;
+    } else if (n === 23) s.italic = false;
+    else if (n === 24) s.underline = false;
+    else if (n === 27) s.inverse = false;
+    else if ((n >= 30 && n <= 37) || (n >= 90 && n <= 97)) s.fg = String(n);
+    else if (n === 39) s.fg = null;
+    else if ((n >= 40 && n <= 47) || (n >= 100 && n <= 107)) s.bg = String(n);
+    else if (n === 49) s.bg = null;
+    else if (n === 38 || n === 48) {
+      // 38;5;n and 38;2;r;g;b: keep the whole extended spec as the color.
+      const len = codes[i + 1] === 5 ? 2 : codes[i + 1] === 2 ? 4 : 0;
+      const spec = codes.slice(i, i + 1 + len).join(";");
+      if (n === 38) s.fg = spec;
+      else s.bg = spec;
+      i += len;
+    }
+  }
+  return s;
+}
+
+/** Canonical `\x1b[...m` for a state, "" for the default state. */
+export function sgrSeq(s) {
+  const codes = [];
+  if (s.bold) codes.push(1);
+  if (s.dim) codes.push(2);
+  if (s.italic) codes.push(3);
+  if (s.underline) codes.push(4);
+  if (s.inverse) codes.push(7);
+  if (s.fg !== null) codes.push(s.fg);
+  if (s.bg !== null) codes.push(s.bg);
+  return codes.length === 0 ? "" : `\x1b[${codes.join(";")}m`;
+}

--- a/packages/cli/scripts/preview/vt.mjs
+++ b/packages/cli/scripts/preview/vt.mjs
@@ -1,0 +1,107 @@
+// Usage: node vt.mjs in.ansi > out.txt
+// Minimal terminal: replays a raw pty transcript (CR, LF, BS, clear-line,
+// clear-to-end, cursor up/down/left/right) and prints the FINAL screen, one
+// text line per row with the SGR state re-emitted inline wherever it changes.
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { applySgr, DEFAULT, sgrSeq } from "./sgr.mjs";
+
+const CSI = /\x1b\[([0-9;?]*)([A-Za-z@`])/y;
+const OSC = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/y;
+
+export function screen(src) {
+  const lines = [[]];
+  let row = 0;
+  let col = 0;
+  let sgr = "";
+  let state = { ...DEFAULT };
+  const line = () => {
+    while (lines.length <= row) lines.push([]);
+    return lines[row];
+  };
+  const put = (ch) => {
+    const l = line();
+    while (l.length < col) l.push({ ch: " ", sgr: "" });
+    l[col++] = { ch, sgr };
+  };
+  for (let i = 0; i < src.length; ) {
+    const ch = src[i];
+    if (ch === "\x1b") {
+      CSI.lastIndex = i;
+      const m = CSI.exec(src);
+      if (m) {
+        const [, params, cmd] = m;
+        const n = Number(params.split(";")[0] || 1);
+        if (cmd === "m") {
+          state = applySgr(state, params);
+          sgr = sgrSeq(state);
+        } else if (cmd === "K") {
+          const l = line();
+          if (params === "2") l.length = 0;
+          else if (params === "1")
+            for (let c = 0; c < Math.min(col, l.length); c++) l[c] = { ch: " ", sgr: "" };
+          else l.length = Math.min(l.length, col);
+        } else if (cmd === "J") {
+          if (params === "2" || params === "3") for (const l of lines) l.length = 0;
+          else if (params === "1") {
+            for (let r = 0; r < row; r++) lines[r].length = 0;
+            for (let c = 0; c < Math.min(col, line().length); c++)
+              lines[row][c] = { ch: " ", sgr: "" };
+          } else {
+            line().length = Math.min(line().length, col);
+            lines.length = row + 1;
+          }
+        } else if (cmd === "A") row = Math.max(0, row - n);
+        else if (cmd === "B") row += n;
+        else if (cmd === "C") col += n;
+        else if (cmd === "D") col = Math.max(0, col - n);
+        else if (cmd === "G") col = Math.max(0, n - 1);
+        // ?25l/?25h and everything else: dropped.
+        i += m[0].length;
+        continue;
+      }
+      OSC.lastIndex = i;
+      const o = OSC.exec(src);
+      i += o ? o[0].length : 2; // ESC + one char (ESC=, ESC>, ESC(B …)
+      continue;
+    }
+    if (ch === "\r") col = 0;
+    else if (ch === "\n") row++;
+    else if (ch === "\x08") col = Math.max(0, col - 1);
+    else if (ch === "\t") col += 8 - (col % 8);
+    else if (ch >= " " && ch !== "\x7f") {
+      const cp = src.codePointAt(i);
+      put(String.fromCodePoint(cp));
+      i += cp > 0xffff ? 2 : 1;
+      continue;
+    }
+    i++;
+  }
+  return lines
+    .map((cells) => {
+      while (
+        cells.length > 0 &&
+        cells[cells.length - 1].ch === " " &&
+        cells[cells.length - 1].sgr === ""
+      )
+        cells.pop();
+      let out = "";
+      let open = "";
+      for (const cell of cells) {
+        if (cell.sgr !== open) {
+          if (open !== "") out += "\x1b[0m";
+          out += cell.sgr;
+          open = cell.sgr;
+        }
+        out += cell.ch;
+      }
+      if (open !== "") out += "\x1b[0m";
+      return out;
+    })
+    .join("\n")
+    .replace(/\n+$/, "");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  process.stdout.write(`${screen(readFileSync(process.argv[2], "utf8"))}\n`);
+}

--- a/packages/cli/src/log.ts
+++ b/packages/cli/src/log.ts
@@ -1,3 +1,4 @@
+import { err, warn } from "./theme.js";
 import { stripControl } from "./utils.js";
 
 export type LogLevel = "error" | "warn" | "info" | "debug";
@@ -37,8 +38,8 @@ export function createLogger({
   };
   return {
     level,
-    error: (message) => write("error", "error: ", message),
-    warn: (message) => write("warn", "warning: ", message),
+    error: (message) => write("error", `${err("error:")} `, message),
+    warn: (message) => write("warn", `${warn("warning:")} `, message),
     info: (message) => write("info", "", message),
     debug: (message) => write("debug", "", message),
   };

--- a/packages/cli/src/session.ts
+++ b/packages/cli/src/session.ts
@@ -8,14 +8,7 @@ import type { Progress, StepHandle } from "./progress.js";
 import { type OnProgress, type Provider, providers, type Source } from "./providers/index.js";
 import { RESEND_BASE_URL_ENV } from "./providers/resend.js";
 import { dim, ok, SYM, wrapIndent } from "./theme.js";
-import {
-  banner,
-  pickBannerTier,
-  secretPrompt,
-  selectPrompt,
-  textPrompt,
-  wrapText,
-} from "./tty-ui.js";
+import { banner, pickBannerTier, secretPrompt, selectPrompt, textPrompt } from "./tty-ui.js";
 import { capitalize, formatNumber } from "./utils.js";
 
 /** MillionSend allows 600 requests per minute per key; batch endpoints keep the real rate far below. */
@@ -41,7 +34,7 @@ export function printHeader(ctx: Context, text: string): void {
     return;
   }
   for (const line of banner(tier)) out.write(`${line}\n`);
-  out.write(`\n${dim(wrapText(text, Math.min(out.columns ?? 80, 80) - 2))}\n\n`);
+  out.write(`\n${dim(wrapIndent(text))}\n\n`);
 }
 
 async function resolveKey(

--- a/packages/cli/test/log.test.ts
+++ b/packages/cli/test/log.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createLogger, redact } from "../src/log.js";
+import { setColorMode } from "../src/theme.js";
 
 describe("redact", () => {
   it("masks every key shape and Authorization values, leaves the rest", () => {
@@ -47,5 +48,23 @@ describe("createLogger", () => {
     log.warn("topics/News\x1b]52;c;cHduZWQ=\x07\x1b[2J\x07: rejected");
     expect(lines).toEqual(["warning: topics/News: rejected\n"]);
     expect(lines.join("")).not.toContain("\x1b");
+  });
+});
+
+describe("createLogger colors", () => {
+  it("colors only the level prefix when color is on, never the message", () => {
+    setColorMode("always");
+    try {
+      const lines: string[] = [];
+      const log = createLogger({ stream: { write: (c: string) => lines.push(c) } });
+      log.error("boom");
+      log.warn("careful");
+      expect(lines).toEqual([
+        "\x1b[31merror:\x1b[39m boom\n",
+        "\x1b[33mwarning:\x1b[39m careful\n",
+      ]);
+    } finally {
+      setColorMode("auto");
+    }
   });
 });


### PR DESCRIPTION
Two follow-ups from the before/after review of the CLI restyle:

- the description under the banner wrapped at 80 columns while the section rules span the 100-column layout width; it now uses the same width
- `error:` / `warning:` prefixes are red / yellow on a terminal (plain when piped, `--color never`, or `NO_COLOR`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)