### PR TITLE
Account mail: a welcome, security receipts, and owner notices for domains, keys, webhooks, members, broadcasts and billing, each in the reader's language

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -303,7 +303,9 @@ deliverability notices, a domain verifying or losing its records, a new API key,
 webhook secret, a member joining, a broadcast that went out or is held, billing on the
 cloud). Broadcast reports go out as the broadcast finishes and billing notices from the
 Stripe webhook itself; the other owner notices ride the ten-minute notification sweep. All
-read in the language of the owner's contact in the team below, else English. Verify the sender's domain under
+read in the language of the owner's contact in the team below, else English; each owner picks
+which notices they get under **Settings → Notifications** (account mail and security receipts are
+always sent). Verify the sender's domain under
 **Domains** in a team and those emails are logged and measured there, tagged
 `millionsend_system`, with their body purged once SES accepts them. Until a team holds the
 domain they go straight through SES and leave no trace.

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -296,11 +296,16 @@ signup deliberately.
 <details>
 <summary><b>Account mail, contacts and product updates</b></summary>
 
-MillionSend's own emails (password resets, email verification, invitations, quota and
-deliverability notices) go out from `AUTH_EMAIL_FROM` / `NOTIFICATIONS_EMAIL_FROM`. Verify
-the sender's domain under **Domains** in a team and those emails are logged and measured
-there, tagged `millionsend_system`, with their body purged once SES accepts them. Until a
-team holds the domain they go straight through SES and leave no trace.
+MillionSend's own emails go out from `AUTH_EMAIL_FROM` / `NOTIFICATIONS_EMAIL_FROM`: to a
+person about their account (password reset, verification, welcome, a password-changed
+receipt, an app granted access) and to a team's owners (invitations, quota and
+deliverability notices, a domain verifying or losing its records, a new API key, a rotated
+webhook secret, a member joining, a broadcast that went out or is held, billing on the
+cloud). Owner notices ride the ten-minute notification sweep and read in the language of
+the owner's contact in the team below, else English. Verify the sender's domain under
+**Domains** in a team and those emails are logged and measured there, tagged
+`millionsend_system`, with their body purged once SES accepts them. Until a team holds the
+domain they go straight through SES and leave no trace.
 
 On an instance with `ALLOW_SIGNUP=true`, every new account becomes a contact of that team
 (`source: signup`) once its address is verified; the sign-up screen says so, and deleting the

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -301,8 +301,9 @@ person about their account (password reset, verification, welcome, a password-ch
 receipt, an app granted access) and to a team's owners (invitations, quota and
 deliverability notices, a domain verifying or losing its records, a new API key, a rotated
 webhook secret, a member joining, a broadcast that went out or is held, billing on the
-cloud). Owner notices ride the ten-minute notification sweep and read in the language of
-the owner's contact in the team below, else English. Verify the sender's domain under
+cloud). Broadcast reports go out as the broadcast finishes and billing notices from the
+Stripe webhook itself; the other owner notices ride the ten-minute notification sweep. All
+read in the language of the owner's contact in the team below, else English. Verify the sender's domain under
 **Domains** in a team and those emails are logged and measured there, tagged
 `millionsend_system`, with their body purged once SES accepts them. Until a team holds the
 domain they go straight through SES and leave no trace.

--- a/apps/docs/content/docs/self-hosting.mdx
+++ b/apps/docs/content/docs/self-hosting.mdx
@@ -156,10 +156,10 @@ deployments — see [Billing](/billing); a self-hosted instance has no plan limi
 | `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET` / `STRIPE_PORTAL_CONFIG` | Hosted cloud only; ignored when `IS_CLOUD=false`. Stripe API key, the signing secret of the webhook endpoint at `/api/billing/webhook`, and an optional customer-portal configuration id. |
 | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | OAuth credentials for "Continue with Google". The button appears only when both are set. Callback URL: `{APP_BASE_URL}/api/auth/callback/google`. |
 | `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` | Same, for GitHub. Callback URL: `{APP_BASE_URL}/api/auth/callback/github`. |
-| `AUTH_EMAIL_FROM` | Sender for account emails (password reset, email verification), as `Name <user@domain>` or a bare address; its domain must be a verified identity in this instance's SES account. Password recovery and sign-up verification only exist when this is set and SES credentials are configured — leave unset to skip both. Verify its domain in a team under **Domains** and those emails are logged there, with new accounts as its contacts (see [Account mail](#account-mail-contacts-and-product-updates)). |
+| `AUTH_EMAIL_FROM` | Sender for the emails to a person about their own account (password reset, email verification, the welcome, a password-changed receipt, an app granted access), as `Name <user@domain>` or a bare address; its domain must be a verified identity in this instance's SES account. Password recovery and sign-up verification only exist when this is set and SES credentials are configured — leave unset to skip both. Verify its domain in a team under **Domains** and those emails are logged there, with new accounts as its contacts (see [Account mail](#account-mail-contacts-and-product-updates)). |
 | `TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET_KEY` | Cloudflare Turnstile keys, both or neither. When set, sign-in, sign-up, password reset and the onboarding "Send email" button verify a challenge token (invisible or managed widgets both work). Unset, every form runs without a captcha. |
 | `ONBOARDING_EMAIL_FROM` | Shared sender for the onboarding "Send email" button and snippet, as `Name <user@domain>` or a bare address on a domain verified in this SES account. Any team may send from it, but only to members who verified their address (where the instance verifies), and always with this exact display name. Leave unset to hide the button; the snippet then asks for the team's own domain. |
-| `NOTIFICATIONS_EMAIL_FROM` | Sender for account notifications to team owners (daily quota nearly or fully used, bounce/complaint rates at risk or paused) and for team invitation emails, same forms as `AUTH_EMAIL_FROM`, which it falls back to. With neither set, only the webhook events go out and invitations are link-only. Verify its domain in a team to log these emails there. |
+| `NOTIFICATIONS_EMAIL_FROM` | Sender for the notices to team owners (daily quota, bounce/complaint rates, a domain verifying or losing its records, a new API key, a rotated webhook secret, a member joining, a broadcast that went out or is held, billing on the cloud) and for team invitation emails, same forms as `AUTH_EMAIL_FROM`, which it falls back to. With neither set, only the webhook events go out and invitations are link-only. Verify its domain in a team to log these emails there. |
 
 ### Worker sizing
 
@@ -607,9 +607,23 @@ you have opened signup deliberately.
 
 ## Account mail, contacts and product updates
 
-MillionSend's own emails — password resets, email verification, team
-invitations, and the quota and deliverability notices to team owners — go out
-from `AUTH_EMAIL_FROM` and `NOTIFICATIONS_EMAIL_FROM`. Verify the sender's
+MillionSend's own emails go out from `AUTH_EMAIL_FROM` and
+`NOTIFICATIONS_EMAIL_FROM`. To a person, about their account: password
+resets, email verification, a welcome once the address is theirs, a receipt
+when a password reset goes through, and one when an MCP app is granted
+access — sent from the request itself. To a team's owners: team invitations,
+the quota and deliverability notices, a domain that verified or lost a
+record (a domain SES gave up on says to add it again), a new API key (also
+to whoever created it), a rotated webhook secret with the old secret's
+deadline, a member who joined, a broadcast that went out — or is waiting for
+the daily quota, or held while its region is paused — and, on the cloud, a
+plan activated, moved or ended, a scheduled cancellation with a reminder
+three days out, and a failed charge. Owner notices come from the
+notification sweep, so they arrive within ten minutes of the change; each is
+written in the language of the reader's contact in the team that holds the
+sender's domain (the row sign-up enrolls, below), else English.
+
+Verify the sender's
 domain under **Domains** in a team, and from then on those emails are logged
 and measured in that team like any other: they appear in its Emails list with
 a `millionsend_system` tag, count in its Metrics, and its Suppressions fill in
@@ -648,6 +662,10 @@ credentials are configured — the same condition as password recovery. A
 password sign-up gets no session until the emailed link is opened; accounts
 from before verify at their next sign-in. Where the instance verifies, the
 onboarding sender only reaches members who did.
+
+On an instance upgrading to this release, domains already verified and
+day-old audit rows are marked as told, but a domain that is demoted at the
+moment of the upgrade is reported as lost on the first sweep.
 
 Nothing on a self-hosted instance contacts millionsend.com on its own. The
 setup wizard offers, once and interactively, to subscribe the operator's

--- a/apps/docs/content/docs/self-hosting.mdx
+++ b/apps/docs/content/docs/self-hosting.mdx
@@ -624,7 +624,9 @@ webhook itself (only the cancellation reminder and a plan lapsing at its
 period end come from the worker); every other owner notice comes from the
 notification sweep, so it arrives within ten minutes of the change. Each is
 written in the language of the reader's contact in the team that holds the
-sender's domain (the row sign-up enrolls, below), else English.
+sender's domain (the row sign-up enrolls, below), else English. Each owner
+chooses which of these notices they get under **Settings → Notifications**;
+mail about a person's own account and the security receipts are always sent.
 
 Verify the sender's
 domain under **Domains** in a team, and from then on those emails are logged

--- a/apps/docs/content/docs/self-hosting.mdx
+++ b/apps/docs/content/docs/self-hosting.mdx
@@ -618,8 +618,11 @@ to whoever created it), a rotated webhook secret with the old secret's
 deadline, a member who joined, a broadcast that went out — or is waiting for
 the daily quota, or held while its region is paused — and, on the cloud, a
 plan activated, moved or ended, a scheduled cancellation with a reminder
-three days out, and a failed charge. Owner notices come from the
-notification sweep, so they arrive within ten minutes of the change; each is
+three days out, and a failed charge. A broadcast report is sent by the
+worker as the broadcast finishes and the billing notices by the Stripe
+webhook itself (only the cancellation reminder and a plan lapsing at its
+period end come from the worker); every other owner notice comes from the
+notification sweep, so it arrives within ten minutes of the change. Each is
 written in the language of the reader's contact in the team that holds the
 sender's domain (the row sign-up enrolls, below), else English.
 

--- a/apps/web/messages/en/settings.json
+++ b/apps/web/messages/en/settings.json
@@ -8,6 +8,7 @@
     "mcp": "MCP",
     "unsubscribe": "Unsubscribe page",
     "connectedApps": "Connected apps",
+    "notifications": "Notifications",
     "audit": "Audit log"
   },
   "smtp": {
@@ -391,5 +392,88 @@
     "loadError": "Could not load the audit log.",
     "retry": "Retry",
     "forbidden": "Only owners and admins can read the audit log."
+  },
+  "notifications": {
+    "title": "Email notifications",
+    "intro": "What MillionSend emails you as an owner of your teams. Each switch applies to every team you own.",
+    "always": "Always sent: mail about your own account (password reset, verification, the welcome, a password change, an app granted access) and the security receipts for API keys and webhook secrets.",
+    "groups": {
+      "domains": "Domains",
+      "team": "Team",
+      "broadcasts": "Broadcasts",
+      "sending": "Sending health",
+      "webhooks": "Webhooks",
+      "billing": "Billing"
+    },
+    "items": {
+      "domain_verified": {
+        "label": "Domain verified",
+        "note": "A sending domain's DNS records check out."
+      },
+      "domain_lost": {
+        "label": "Domain lost its verification",
+        "note": "A record disappeared, or SES gave up on the domain."
+      },
+      "member_joined": {
+        "label": "Member joined",
+        "note": "Someone accepted an invitation to a team you own."
+      },
+      "broadcast_sent": {
+        "label": "Broadcast sent",
+        "note": "The recipient count once a broadcast has gone out."
+      },
+      "broadcast_held_quota": {
+        "label": "Broadcast waiting for the quota",
+        "note": "Part of a broadcast is parked over the daily cap."
+      },
+      "broadcast_held": {
+        "label": "Broadcast on hold",
+        "note": "Sending from its region is paused across the platform."
+      },
+      "quota": {
+        "label": "Daily quota",
+        "note": "Nearing, reaching and running past the day's cap."
+      },
+      "deliverability": {
+        "label": "Deliverability",
+        "note": "Bounce or complaint rates at risk, or sending paused."
+      },
+      "webhook_failing": {
+        "label": "Webhook endpoint failing",
+        "note": "Every recent delivery to an endpoint failed."
+      },
+      "webhook_auto_disabled": {
+        "label": "Webhook endpoint disabled",
+        "note": "An endpoint was switched off after failing for too long."
+      },
+      "webhook_backlog": {
+        "label": "Webhook backlog",
+        "note": "Deliveries to an endpoint are queuing up."
+      },
+      "billing_payment_failed": {
+        "label": "Payment failed",
+        "note": "A charge for the plan was declined."
+      },
+      "billing_plan_activated": {
+        "label": "Plan activated",
+        "note": "A paid plan started."
+      },
+      "billing_plan_changed": {
+        "label": "Plan changed",
+        "note": "The team moved between paid plans."
+      },
+      "billing_cancel_scheduled": {
+        "label": "Cancellation scheduled",
+        "note": "The plan will end when the period closes."
+      },
+      "billing_cancel_reminder": {
+        "label": "Cancellation reminder",
+        "note": "Three days before a scheduled end."
+      },
+      "billing_downgraded": {
+        "label": "Back on Free",
+        "note": "The paid plan ended."
+      }
+    }
   }
 }

--- a/apps/web/messages/pt-BR/settings.json
+++ b/apps/web/messages/pt-BR/settings.json
@@ -8,6 +8,7 @@
     "mcp": "MCP",
     "unsubscribe": "Página de cancelamento",
     "connectedApps": "Aplicativos conectados",
+    "notifications": "Notificações",
     "audit": "Registro de auditoria"
   },
   "smtp": {
@@ -391,5 +392,88 @@
     "loadError": "Não foi possível carregar o registro de auditoria.",
     "retry": "Tentar de novo",
     "forbidden": "Somente proprietários e administradores podem ler o registro de auditoria."
+  },
+  "notifications": {
+    "title": "Notificações por e-mail",
+    "intro": "O que o MillionSend envia a você como proprietário das suas equipes. Cada opção vale para todas as equipes que você possui.",
+    "always": "Sempre enviados: e-mails sobre a sua própria conta (redefinição de senha, verificação, boas-vindas, senha alterada, app autorizado) e os recibos de segurança de chaves de API e segredos de webhook.",
+    "groups": {
+      "domains": "Domínios",
+      "team": "Equipe",
+      "broadcasts": "Broadcasts",
+      "sending": "Saúde do envio",
+      "webhooks": "Webhooks",
+      "billing": "Cobrança"
+    },
+    "items": {
+      "domain_verified": {
+        "label": "Domínio verificado",
+        "note": "Os registros DNS de um domínio de envio estão corretos."
+      },
+      "domain_lost": {
+        "label": "Domínio perdeu a verificação",
+        "note": "Um registro sumiu, ou o SES desistiu do domínio."
+      },
+      "member_joined": {
+        "label": "Membro entrou",
+        "note": "Alguém aceitou um convite para uma equipe sua."
+      },
+      "broadcast_sent": {
+        "label": "Broadcast enviado",
+        "note": "O número de destinatários quando um broadcast sai."
+      },
+      "broadcast_held_quota": {
+        "label": "Broadcast aguardando a cota",
+        "note": "Parte de um broadcast ficou retida acima do limite diário."
+      },
+      "broadcast_held": {
+        "label": "Broadcast em espera",
+        "note": "O envio da região está pausado em toda a plataforma."
+      },
+      "quota": {
+        "label": "Cota diária",
+        "note": "Ao se aproximar, atingir e passar do limite do dia."
+      },
+      "deliverability": {
+        "label": "Entregabilidade",
+        "note": "Taxas de bounce ou reclamação em risco, ou envio pausado."
+      },
+      "webhook_failing": {
+        "label": "Endpoint de webhook falhando",
+        "note": "Todas as entregas recentes a um endpoint falharam."
+      },
+      "webhook_auto_disabled": {
+        "label": "Endpoint de webhook desativado",
+        "note": "Um endpoint foi desligado depois de falhar por muito tempo."
+      },
+      "webhook_backlog": {
+        "label": "Fila de webhooks",
+        "note": "As entregas a um endpoint estão se acumulando."
+      },
+      "billing_payment_failed": {
+        "label": "Pagamento recusado",
+        "note": "Uma cobrança do plano foi recusada."
+      },
+      "billing_plan_activated": {
+        "label": "Plano ativado",
+        "note": "Um plano pago começou."
+      },
+      "billing_plan_changed": {
+        "label": "Plano alterado",
+        "note": "A equipe mudou entre planos pagos."
+      },
+      "billing_cancel_scheduled": {
+        "label": "Cancelamento agendado",
+        "note": "O plano termina no fim do período."
+      },
+      "billing_cancel_reminder": {
+        "label": "Lembrete de cancelamento",
+        "note": "Três dias antes de um término agendado."
+      },
+      "billing_downgraded": {
+        "label": "De volta ao Free",
+        "note": "O plano pago terminou."
+      }
+    }
   }
 }

--- a/apps/web/src/app/(dashboard)/settings/notifications/notifications-view.tsx
+++ b/apps/web/src/app/(dashboard)/settings/notifications/notifications-view.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { MAIL_PREFERENCE_GROUPS, type MailPreferenceKey } from "@millionsend/core/mail-preferences";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { Skeleton } from "@/components/skeleton";
+import { Switch } from "@/components/switch";
+import { useTRPC } from "@/lib/trpc";
+
+/** Message ids cannot carry dots: "broadcast.held_quota" reads as "broadcast_held_quota". */
+const itemId = (key: MailPreferenceKey) => key.replace(/\./g, "_");
+
+export function NotificationsView({ cloud }: { cloud: boolean }) {
+  const t = useTranslations("settings.notifications");
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { data } = useQuery(trpc.settings.mailPreferences.get.queryOptions());
+  const set = useMutation(
+    trpc.settings.mailPreferences.set.mutationOptions({
+      onSuccess: async () => {
+        await queryClient.invalidateQueries(trpc.settings.mailPreferences.get.queryFilter());
+      },
+    }),
+  );
+  const off = new Set<string>(data?.optOuts ?? []);
+  return (
+    <div style={{ maxWidth: 640, display: "grid", gap: 16 }}>
+      <p style={{ margin: 0, fontSize: 13, color: "var(--ms-muted)" }}>{t("intro")}</p>
+      {MAIL_PREFERENCE_GROUPS.filter((group) => cloud || !group.cloudOnly).map((group) => (
+        <section key={group.group} className="ms-card" style={{ padding: 24 }}>
+          <h2
+            className="ms-display"
+            style={{ fontSize: "var(--ms-fs-h2)", color: "var(--ms-bone)", margin: "0 0 18px" }}
+          >
+            {t(`groups.${group.group}`)}
+          </h2>
+          {group.keys.map((key) => (
+            <div
+              key={key}
+              style={{
+                display: "flex",
+                alignItems: "flex-start",
+                justifyContent: "space-between",
+                gap: 16,
+                marginBottom: 14,
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <span
+                  style={{
+                    display: "block",
+                    fontSize: "var(--ms-fs-label)",
+                    color: "var(--ms-bone)",
+                    marginBottom: 2,
+                  }}
+                >
+                  {t(`items.${itemId(key)}.label`)}
+                </span>
+                <span style={{ display: "block", fontSize: 12, color: "var(--ms-muted)" }}>
+                  {t(`items.${itemId(key)}.note`)}
+                </span>
+              </div>
+              {data ? (
+                <Switch
+                  checked={!off.has(key)}
+                  disabled={set.isPending}
+                  onChange={(enabled) => set.mutate({ key, enabled })}
+                  ariaLabel={t(`items.${itemId(key)}.label`)}
+                />
+              ) : (
+                <Skeleton width={40} height={22} radius={999} />
+              )}
+            </div>
+          ))}
+        </section>
+      ))}
+      <p style={{ margin: 0, fontSize: 12, color: "var(--ms-muted)" }}>{t("always")}</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(dashboard)/settings/notifications/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/notifications/page.tsx
@@ -1,0 +1,17 @@
+import { env } from "@millionsend/config";
+import { getTranslations } from "next-intl/server";
+import { PageHeader } from "@/components/page-header";
+import { SettingsTabs } from "../settings-tabs";
+import { NotificationsView } from "./notifications-view";
+
+export default async function NotificationsSettingsPage() {
+  const t = await getTranslations("settings");
+  return (
+    <>
+      <PageHeader title={t("notifications.title")} />
+      <SettingsTabs />
+      {/* Billing notices exist only where billing does. */}
+      <NotificationsView cloud={env.IS_CLOUD} />
+    </>
+  );
+}

--- a/apps/web/src/app/(dashboard)/settings/settings-tabs-nav.tsx
+++ b/apps/web/src/app/(dashboard)/settings/settings-tabs-nav.tsx
@@ -14,6 +14,7 @@ const TABS = [
   { key: "smtp", href: "/settings/smtp" },
   { key: "mcp", href: "/settings/mcp" },
   { key: "connectedApps", href: "/settings/connected-apps" },
+  { key: "notifications", href: "/settings/notifications" },
   { key: "unsubscribe", href: "/settings/unsubscribe" },
   { key: "audit", href: "/settings/audit" },
 ] as const;

--- a/apps/web/src/app/api/billing/webhook/route.ts
+++ b/apps/web/src/app/api/billing/webhook/route.ts
@@ -183,7 +183,7 @@ async function mailOwners(db: Db, event: BillingEvent, before: PlanRow, after: P
     values: (locale: MailLocale) => Record<string, string>,
     url?: string,
   ) => {
-    for (const owner of await listTeamOwners(db, after.id, accountEmailFrom())) {
+    for (const owner of await listTeamOwners(db, after.id, accountEmailFrom(), kind)) {
       sendAccountMail(
         buildAccountEmail({
           from,

--- a/apps/web/src/app/api/billing/webhook/route.ts
+++ b/apps/web/src/app/api/billing/webhook/route.ts
@@ -1,10 +1,27 @@
 import { handleWebhook, isLiveKey } from "@millionsend/billing";
-import { env } from "@millionsend/config";
-import { effectivePlan, raisesDailyLimit, recordAudit } from "@millionsend/core";
+import { accountEmailFrom, env } from "@millionsend/config";
+import {
+  type AccountMailKind,
+  accountMailPhrase,
+  claimNotification,
+  effectivePlan,
+  formatMailDate,
+  listTeamOwners,
+  type MailLocale,
+  PLAN_DAILY_LIMIT,
+  PLAN_NAME,
+  planCapPhrase,
+  raisesDailyLimit,
+  recordAudit,
+} from "@millionsend/core";
 import { type Db, getDb, schema } from "@millionsend/db";
 import { eq } from "drizzle-orm";
+import { appBaseUrl } from "@/lib/api-base-url";
 import { getStripe } from "@/server/billing";
 import { getQueue } from "@/server/queue";
+import { buildAccountEmail, sendAccountMail } from "@/server/system-mail";
+
+const BILLING_PATH = "/settings/billing";
 
 /**
  * Stripe webhook endpoint. Unauthenticated by design: the raw body is
@@ -56,23 +73,68 @@ export async function POST(request: Request) {
         }
       }
     }
+    if (after) {
+      try {
+        await mailOwners(db, event, before, after);
+      } catch (err) {
+        console.error("billing webhook: owner mail skipped", err);
+      }
+    }
   }
   return new Response(null, { status });
 }
 
-function parseEvent(rawBody: string): { type: string; customerId: string } | null {
+interface BillingEvent {
+  type: string;
+  customerId: string;
+  /** Set on invoice events; how Stripe reports a failed charge and its own retry. */
+  invoice: {
+    id: string;
+    attemptCount: number;
+    nextAttempt: Date | null;
+    hostedUrl: string | null;
+  } | null;
+}
+
+function parseEvent(rawBody: string): BillingEvent | null {
   try {
     const parsed: unknown = JSON.parse(rawBody);
     if (typeof parsed !== "object" || parsed === null) return null;
-    const { type, data } = parsed as { type?: unknown; data?: { object?: { customer?: unknown } } };
-    const customer = data?.object?.customer;
+    const { type, data } = parsed as {
+      type?: unknown;
+      data?: {
+        object?: {
+          id?: unknown;
+          customer?: unknown;
+          attempt_count?: unknown;
+          next_payment_attempt?: unknown;
+          hosted_invoice_url?: unknown;
+        };
+      };
+    };
+    const object = data?.object;
+    const customer = object?.customer;
     const customerId =
       typeof customer === "string"
         ? customer
         : typeof customer === "object" && customer !== null && "id" in customer
           ? String(customer.id)
           : null;
-    return typeof type === "string" && customerId ? { type, customerId } : null;
+    if (typeof type !== "string" || !customerId) return null;
+    const invoice =
+      type.startsWith("invoice.") && typeof object?.id === "string"
+        ? {
+            id: object.id,
+            attemptCount: typeof object.attempt_count === "number" ? object.attempt_count : 0,
+            nextAttempt:
+              typeof object.next_payment_attempt === "number"
+                ? new Date(object.next_payment_attempt * 1000)
+                : null,
+            hostedUrl:
+              typeof object.hosted_invoice_url === "string" ? object.hosted_invoice_url : null,
+          }
+        : null;
+    return { type, customerId, invoice };
   } catch {
     return null;
   }
@@ -82,11 +144,121 @@ async function planOf(db: Db, customerId: string) {
   const [team] = await db
     .select({
       id: schema.teams.id,
+      name: schema.teams.name,
       plan: schema.teams.plan,
       planStatus: schema.teams.planStatus,
       currentPeriodEnd: schema.teams.currentPeriodEnd,
+      cancelAt: schema.teams.cancelAt,
     })
     .from(schema.teams)
     .where(eq(schema.teams.stripeCustomerId, customerId));
   return team ?? null;
+}
+
+type PlanRow = NonNullable<Awaited<ReturnType<typeof planOf>>>;
+
+/**
+ * What the owners hear about, read off the row before and after the event
+ * rather than off the event itself, so a redelivered or reordered event says
+ * nothing twice: activation and changes are the plan moving, a scheduled
+ * cancellation is cancel_at appearing on a paid plan, and a downgrade is the
+ * plan reaching free, which also covers an immediate cancellation. A failed
+ * charge leaves the plan alone and is claimed per invoice attempt instead.
+ */
+async function mailOwners(db: Db, event: BillingEvent, before: PlanRow, after: PlanRow) {
+  const from = accountEmailFrom();
+  if (!from) return;
+  const team = after.name;
+  const freeCap = (locale: MailLocale) => (PLAN_DAILY_LIMIT.free ?? 0).toLocaleString(locale);
+  const send = async (
+    kind: AccountMailKind,
+    values: (locale: MailLocale) => Record<string, string>,
+    url?: string,
+  ) => {
+    for (const owner of await listTeamOwners(db, after.id, from)) {
+      sendAccountMail(
+        buildAccountEmail({
+          to: owner.email,
+          kind,
+          locale: owner.locale,
+          path: BILLING_PATH,
+          url,
+          values: values(owner.locale),
+        }),
+      );
+    }
+  };
+
+  if (event.type === "invoice.payment_failed" && event.invoice && after.planStatus === "past_due") {
+    const { id, attemptCount, nextAttempt, hostedUrl } = event.invoice;
+    const claimed = await claimNotification(db, {
+      teamId: after.id,
+      kind: "billing.payment_failed",
+      periodKey: `${id}:${attemptCount}`,
+    });
+    if (claimed) {
+      await send(
+        "billing.payment_failed",
+        (locale) => ({
+          team,
+          plan: PLAN_NAME[after.plan],
+          cap: planCapPhrase(locale, after.plan),
+          freeCap: freeCap(locale),
+          retry: nextAttempt
+            ? accountMailPhrase({
+                locale,
+                kind: "billing.payment_failed",
+                key: "retryOn",
+                values: { date: formatMailDate(locale, nextAttempt) },
+              })
+            : accountMailPhrase({ locale, kind: "billing.payment_failed", key: "noRetry" }),
+          billingUrl: `${appBaseUrl()}${BILLING_PATH}`,
+        }),
+        hostedUrl ?? undefined,
+      );
+    }
+  }
+
+  if (before.plan !== "free" && after.plan === "free") {
+    // The sweep claims the same kind with the same period end when the grace
+    // window lapses before Stripe's event arrives; whichever runs first wins.
+    const claimed = await claimNotification(db, {
+      teamId: after.id,
+      kind: "billing.downgraded",
+      periodKey: before.currentPeriodEnd?.toISOString() ?? "none",
+    });
+    if (claimed) {
+      const ended = before.currentPeriodEnd ?? before.cancelAt ?? new Date();
+      await send("billing.downgraded", (locale) => ({
+        team,
+        plan: PLAN_NAME[before.plan],
+        date: formatMailDate(locale, ended),
+        freeCap: freeCap(locale),
+      }));
+    }
+    return;
+  }
+  if (before.plan === "free" && after.plan !== "free") {
+    await send("billing.plan_activated", (locale) => ({
+      team,
+      plan: PLAN_NAME[after.plan],
+      cap: planCapPhrase(locale, after.plan),
+    }));
+  } else if (before.plan !== after.plan) {
+    await send("billing.plan_changed", (locale) => ({
+      team,
+      old: PLAN_NAME[before.plan],
+      new: PLAN_NAME[after.plan],
+      cap: planCapPhrase(locale, after.plan),
+    }));
+  }
+  if (before.cancelAt === null && after.cancelAt !== null && after.plan !== "free") {
+    const endsAt = after.cancelAt;
+    await send("billing.cancel_scheduled", (locale) => ({
+      team,
+      plan: PLAN_NAME[after.plan],
+      date: formatMailDate(locale, endsAt),
+      freeCap: freeCap(locale),
+    }));
+  }
 }

--- a/apps/web/src/app/api/billing/webhook/route.ts
+++ b/apps/web/src/app/api/billing/webhook/route.ts
@@ -1,9 +1,12 @@
 import { handleWebhook, isLiveKey } from "@millionsend/billing";
-import { accountEmailFrom, env } from "@millionsend/config";
+import { accountEmailFrom, env, notificationsEmailFrom } from "@millionsend/config";
 import {
   type AccountMailKind,
   accountMailPhrase,
+  CANCEL_REMINDER_DAYS,
   claimNotification,
+  clearNotifications,
+  DAY_MS,
   effectivePlan,
   formatMailDate,
   listTeamOwners,
@@ -11,6 +14,7 @@ import {
   PLAN_DAILY_LIMIT,
   PLAN_NAME,
   planCapPhrase,
+  planMove,
   raisesDailyLimit,
   recordAudit,
 } from "@millionsend/core";
@@ -159,25 +163,30 @@ type PlanRow = NonNullable<Awaited<ReturnType<typeof planOf>>>;
 
 /**
  * What the owners hear about, read off the row before and after the event
- * rather than off the event itself, so a redelivered or reordered event says
- * nothing twice: activation and changes are the plan moving, a scheduled
- * cancellation is cancel_at appearing on a paid plan, and a downgrade is the
- * plan reaching free, which also covers an immediate cancellation. A failed
- * charge leaves the plan alone and is claimed per invoice attempt instead.
+ * rather than off the event itself: activation and changes are the plan
+ * moving, a scheduled cancellation is cancel_at appearing on a paid plan,
+ * and a downgrade is the plan reaching free, which also covers an immediate
+ * cancellation. Every mail is claimed, because Stripe delivers a checkout's
+ * events in parallel and each request snapshots `before` outside the
+ * customer lock, so all of them see the same move. A failed charge leaves
+ * the plan alone and is claimed per invoice attempt.
  */
 async function mailOwners(db: Db, event: BillingEvent, before: PlanRow, after: PlanRow) {
-  const from = accountEmailFrom();
+  const from = notificationsEmailFrom();
   if (!from) return;
   const team = after.name;
   const freeCap = (locale: MailLocale) => (PLAN_DAILY_LIMIT.free ?? 0).toLocaleString(locale);
+  const claim = (kind: AccountMailKind, periodKey: string) =>
+    claimNotification(db, { teamId: after.id, kind, periodKey });
   const send = async (
     kind: AccountMailKind,
     values: (locale: MailLocale) => Record<string, string>,
     url?: string,
   ) => {
-    for (const owner of await listTeamOwners(db, after.id, from)) {
+    for (const owner of await listTeamOwners(db, after.id, accountEmailFrom())) {
       sendAccountMail(
         buildAccountEmail({
+          from,
           to: owner.email,
           kind,
           locale: owner.locale,
@@ -191,12 +200,7 @@ async function mailOwners(db: Db, event: BillingEvent, before: PlanRow, after: P
 
   if (event.type === "invoice.payment_failed" && event.invoice && after.planStatus === "past_due") {
     const { id, attemptCount, nextAttempt, hostedUrl } = event.invoice;
-    const claimed = await claimNotification(db, {
-      teamId: after.id,
-      kind: "billing.payment_failed",
-      periodKey: `${id}:${attemptCount}`,
-    });
-    if (claimed) {
+    if (await claim("billing.payment_failed", `${id}:${attemptCount}`)) {
       await send(
         "billing.payment_failed",
         (locale) => ({
@@ -219,41 +223,27 @@ async function mailOwners(db: Db, event: BillingEvent, before: PlanRow, after: P
     }
   }
 
-  if (before.plan !== "free" && after.plan === "free") {
-    // The sweep claims the same kind with the same period end when the grace
-    // window lapses before Stripe's event arrives; whichever runs first wins.
-    const claimed = await claimNotification(db, {
-      teamId: after.id,
-      kind: "billing.downgraded",
-      periodKey: before.currentPeriodEnd?.toISOString() ?? "none",
-    });
-    if (claimed) {
-      const ended = before.currentPeriodEnd ?? before.cancelAt ?? new Date();
-      await send("billing.downgraded", (locale) => ({
-        team,
-        plan: PLAN_NAME[before.plan],
-        date: formatMailDate(locale, ended),
-        freeCap: freeCap(locale),
-      }));
+  // The daily reconcile and the grace sweep claim a move with the same key.
+  const move = planMove(before, after);
+  if (move) {
+    if (await claim(move.kind, move.periodKey)) {
+      await send(move.kind, (locale) => move.values(locale, team));
     }
-    return;
+    if (move.kind === "billing.downgraded") return;
   }
-  if (before.plan === "free" && after.plan !== "free") {
-    await send("billing.plan_activated", (locale) => ({
-      team,
-      plan: PLAN_NAME[after.plan],
-      cap: planCapPhrase(locale, after.plan),
-    }));
-  } else if (before.plan !== after.plan) {
-    await send("billing.plan_changed", (locale) => ({
-      team,
-      old: PLAN_NAME[before.plan],
-      new: PLAN_NAME[after.plan],
-      cap: planCapPhrase(locale, after.plan),
-    }));
+  if (before.cancelAt !== null && after.cancelAt === null) {
+    // Resumed: a later cancellation, even for the same date, is news again.
+    await clearNotifications(db, { teamId: after.id, kind: "billing.cancel_scheduled" });
+    await clearNotifications(db, { teamId: after.id, kind: "billing.cancel_reminder" });
   }
   if (before.cancelAt === null && after.cancelAt !== null && after.plan !== "free") {
     const endsAt = after.cancelAt;
+    if (!(await claim("billing.cancel_scheduled", endsAt.toISOString()))) return;
+    // Scheduled inside the reminder window, this notice is the reminder:
+    // holding the sweep's claim keeps it from saying the same minutes later.
+    if (endsAt.getTime() <= Date.now() + CANCEL_REMINDER_DAYS * DAY_MS) {
+      await claim("billing.cancel_reminder", endsAt.toISOString());
+    }
     await send("billing.cancel_scheduled", (locale) => ({
       team,
       plan: PLAN_NAME[after.plan],

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -13,7 +13,7 @@ import { type BetterAuthPlugin, betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError, createAuthMiddleware } from "better-auth/api";
 import { captcha, jwt } from "better-auth/plugins";
-import { and, eq, ne, notExists } from "drizzle-orm";
+import { and, desc, eq, ne, notExists } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { headers } from "next/headers";
 import { mcpResourceUrl, resolveBaseUrl } from "@/lib/api-base-url";
@@ -22,10 +22,14 @@ import { localeFromHeaders } from "./locale";
 import { getActiveMembership, listMemberships } from "./membership";
 import { enqueueRecipientErase } from "./queue";
 import {
+  buildMcpConnectedEmail,
+  buildPasswordChangedEmail,
+  buildWelcomeEmail,
   emailVerificationEnabled,
   passwordRecoveryEnabled,
   RESET_TOKEN_TTL_MINUTES,
   type SystemMailDeps,
+  sendAccountMail,
   sendPasswordResetEmail,
   sendVerificationEmail,
   VERIFY_TOKEN_TTL_MINUTES,
@@ -188,27 +192,85 @@ export function createAuth(
    * the address is verified, or this instance cannot verify anyone (no
    * sender to send the link) and the account is all there is. An address
    * merely typed at sign-up may be someone else's inbox, so it waits for
-   * the verification link. A self-host closed to sign-up has nobody to
-   * market to and does not enroll; the cloud enrolls whatever the flag says,
-   * since it closes sign-up for reasons of its own. Best-effort: the account
-   * exists whatever happens here.
+   * the verification link. Every account the instance admits is welcomed
+   * then; a self-host closed to sign-up has nobody to market to and does not
+   * enroll, while the cloud enrolls whatever the flag says, since it closes
+   * sign-up for reasons of its own. Best-effort: the account exists whatever
+   * happens here.
    */
   const enrollAccount = async (
     user: { email: string; name: string; emailVerified: boolean },
     headers: Headers | undefined,
   ) => {
     try {
-      if (!signupOpen() && !isCloudDeployment()) return;
       if (emailVerificationEnabled() && !user.emailVerified) return;
+      const locale = localeFromHeaders(headers);
+      if (accountEmailFrom()) {
+        sendAccountMail(buildWelcomeEmail({ to: user.email, name: user.name, locale }), mail);
+      }
+      if (!signupOpen() && !isCloudDeployment()) return;
       const owner = await accountMailTeam(db);
       if (!owner) return;
-      await enrollSystemContact(db, owner.teamId, {
-        email: user.email,
-        name: user.name,
-        locale: localeFromHeaders(headers),
-      });
+      await enrollSystemContact(db, owner.teamId, { email: user.email, name: user.name, locale });
     } catch (error) {
       console.error("Account-mail contact enrollment failed", error);
+    }
+  };
+  /**
+   * A consent just granted to an MCP client is a receipt to its user: the
+   * app can act in their name until revoked. The provider stamps a new
+   * consent row with one instant for both dates and moves only updatedAt on
+   * a re-consent, so a row whose dates differ is a repeat and stays silent.
+   */
+  const mailConsent = async (ctx: {
+    body?: unknown;
+    headers?: Headers | undefined;
+    context: { returned?: unknown; session?: { user: { id: string; email: string } } | null };
+  }) => {
+    try {
+      if (!accountEmailFrom()) return;
+      if ((ctx.body as { accept?: unknown } | undefined)?.accept !== true) return;
+      if (ctx.context.returned instanceof APIError) return;
+      const user = ctx.context.session?.user;
+      if (!user) return;
+      const [consent] = await db
+        .select({
+          app: schema.oauthClient.name,
+          scopes: schema.oauthConsent.scopes,
+          referenceId: schema.oauthConsent.referenceId,
+          createdAt: schema.oauthConsent.createdAt,
+          updatedAt: schema.oauthConsent.updatedAt,
+        })
+        .from(schema.oauthConsent)
+        .innerJoin(
+          schema.oauthClient,
+          eq(schema.oauthClient.clientId, schema.oauthConsent.clientId),
+        )
+        .where(eq(schema.oauthConsent.userId, user.id))
+        .orderBy(desc(schema.oauthConsent.updatedAt))
+        .limit(1);
+      if (!consent || consent.createdAt?.getTime() !== consent.updatedAt?.getTime()) return;
+      let team: string | "*" = "*";
+      if (consent.referenceId && consent.referenceId !== ALL_TEAMS_GRANT) {
+        const [row] = await db
+          .select({ name: schema.teams.name })
+          .from(schema.teams)
+          .where(eq(schema.teams.id, consent.referenceId));
+        if (!row) return;
+        team = row.name;
+      }
+      sendAccountMail(
+        buildMcpConnectedEmail({
+          to: user.email,
+          app: consent.app ?? "An app",
+          team,
+          scopes: consent.scopes,
+          locale: localeFromHeaders(ctx.headers),
+        }),
+        mail,
+      );
+    } catch (error) {
+      console.error("Connected-app email skipped", error);
     }
   };
   return betterAuth({
@@ -328,6 +390,18 @@ export function createAuth(
       maxPasswordLength: 128,
       revokeSessionsOnPasswordReset: true,
       resetPasswordTokenExpiresIn: RESET_TOKEN_TTL_MINUTES * 60,
+      // The receipt for a reset that went through: whoever holds the inbox
+      // learns the password changed and can start a reset of their own.
+      onPasswordReset: async ({ user }: { user: { email: string } }, request?: Request) => {
+        if (!accountEmailFrom()) return;
+        sendAccountMail(
+          buildPasswordChangedEmail({
+            to: user.email,
+            locale: localeFromHeaders(request?.headers),
+          }),
+          mail,
+        );
+      },
       // A password sign-up gets no session until its address is verified;
       // an account from before this verifies at its next sign-in, where the
       // link is re-sent (sendOnSignIn). Gated like recovery: an instance
@@ -473,6 +547,10 @@ export function createAuth(
       // consent remains the gate. drizzle/0007 does the same for clients
       // registered before this hook existed.
       after: createAuthMiddleware(async (ctx) => {
+        if (ctx.path === "/oauth2/consent") {
+          await mailConsent(ctx);
+          return;
+        }
         if (ctx.path !== "/oauth2/register") return;
         const returned = ctx.context.returned;
         const clientId =

--- a/apps/web/src/server/onboarding-mail.ts
+++ b/apps/web/src/server/onboarding-mail.ts
@@ -1,10 +1,11 @@
+import { MAIL_LOCALES, type MailLocale } from "@millionsend/core";
 import { EMAIL_WORDMARK_URL, escapeHtml } from "@millionsend/core/html";
 import en from "../../messages/en/onboarding-email.json";
 import ptBR from "../../messages/pt-BR/onboarding-email.json";
 
 const MESSAGES = { en, "pt-BR": ptBR } as const;
-export const MAIL_LOCALES = ["en", "pt-BR"] as const;
-export type MailLocale = (typeof MAIL_LOCALES)[number];
+
+export { MAIL_LOCALES, type MailLocale };
 
 /**
  * The onboarding "Send email" body in the dashboard's locale: the first

--- a/apps/web/src/server/routers/settings.ts
+++ b/apps/web/src/server/routers/settings.ts
@@ -8,6 +8,9 @@ import {
   INVITE_MAX_SENDS,
   INVITE_RESEND_COOLDOWN_MS,
   INVITE_TTL_MS,
+  isMailPreferenceKey,
+  MAIL_PREFERENCE_KEYS,
+  type MailPreferenceKey,
   PLAN_DAILY_LIMIT,
   type Plan,
   SystemMailRefused,
@@ -788,6 +791,40 @@ export function createSettingsRouter(
       }),
     }),
 
+    /**
+     * The owner notices this person receives, across every team they own.
+     * Stored as the keys turned off, so a switch added later is on for
+     * everyone; the writes are jsonb set operations, so two tabs toggling
+     * at once cannot undo each other.
+     */
+    mailPreferences: router({
+      get: protectedProcedure.query(async ({ ctx }) => {
+        return { optOuts: await mailOptOuts(ctx.db, ctx.session.user.id) };
+      }),
+
+      set: protectedProcedure
+        .input(
+          z.object({
+            key: z.enum(MAIL_PREFERENCE_KEYS as [MailPreferenceKey, ...MailPreferenceKey[]]),
+            enabled: z.boolean(),
+          }),
+        )
+        .mutation(async ({ ctx, input }) => {
+          const u = schema.user;
+          const without = sql`${u.mailOptOuts} - ${input.key}`;
+          await ctx.db
+            .update(u)
+            .set({
+              mailOptOuts: input.enabled
+                ? without
+                : sql`(${without}) || ${JSON.stringify([input.key])}::jsonb`,
+              updatedAt: new Date(),
+            })
+            .where(eq(u.id, ctx.session.user.id));
+          return { optOuts: await mailOptOuts(ctx.db, ctx.session.user.id) };
+        }),
+    }),
+
     unsubscribe: router({
       get: teamProcedure.query(async ({ ctx }) => {
         const [team] = await ctx.db
@@ -898,6 +935,15 @@ export function createSettingsRouter(
         }),
     }),
   });
+}
+
+/** The keys a person turned off, as stored; a key the app no longer knows is dropped on read. */
+async function mailOptOuts(db: Db, userId: string): Promise<MailPreferenceKey[]> {
+  const [row] = await db
+    .select({ optOuts: schema.user.mailOptOuts })
+    .from(schema.user)
+    .where(eq(schema.user.id, userId));
+  return (row?.optOuts ?? []).filter(isMailPreferenceKey);
 }
 
 export const settingsRouter = createSettingsRouter();

--- a/apps/web/src/server/system-mail.ts
+++ b/apps/web/src/server/system-mail.ts
@@ -193,11 +193,13 @@ export function buildInvitationEmail(input: {
 }
 
 /** One catalog kind, from the account sender, addressed to a person. */
-function accountMail(input: {
+/** One account mail on the shared card; the button opens `path` on this instance unless `url` says elsewhere. */
+export function buildAccountEmail(input: {
   to: string;
   kind: AccountMailKind;
   locale: MailLocale;
   path: string;
+  url?: string | undefined;
   values?: Record<string, string>;
 }): SystemMailMessage {
   return {
@@ -206,7 +208,7 @@ function accountMail(input: {
     ...buildAccountMail({
       kind: input.kind,
       locale: input.locale,
-      url: `${appBaseUrl()}${input.path}`,
+      url: input.url ?? `${appBaseUrl()}${input.path}`,
       ...(input.values ? { values: input.values } : {}),
     }),
     kind: input.kind,
@@ -219,7 +221,7 @@ export function buildWelcomeEmail(input: {
   name: string;
   locale: MailLocale;
 }): SystemMailMessage {
-  return accountMail({
+  return buildAccountEmail({
     to: input.to,
     kind: "welcome",
     locale: input.locale,
@@ -233,7 +235,7 @@ export function buildPasswordChangedEmail(input: {
   to: string;
   locale: MailLocale;
 }): SystemMailMessage {
-  return accountMail({
+  return buildAccountEmail({
     to: input.to,
     kind: "password_changed",
     locale: input.locale,
@@ -254,7 +256,7 @@ export function buildMcpConnectedEmail(input: {
     input.team === "*"
       ? accountMailPhrase({ locale: input.locale, kind: "mcp.connected", key: "allTeams" })
       : input.team;
-  return accountMail({
+  return buildAccountEmail({
     to: input.to,
     kind: "mcp.connected",
     locale: input.locale,

--- a/apps/web/src/server/system-mail.ts
+++ b/apps/web/src/server/system-mail.ts
@@ -193,17 +193,23 @@ export function buildInvitationEmail(input: {
 }
 
 /** One catalog kind, from the account sender, addressed to a person. */
-/** One account mail on the shared card; the button opens `path` on this instance unless `url` says elsewhere. */
+/**
+ * One account mail on the shared card; the button opens `path` on this
+ * instance unless `url` says elsewhere. Mail to a person about their own
+ * account goes from the account sender; an owner notice passes the
+ * notifications sender, as the worker's do.
+ */
 export function buildAccountEmail(input: {
   to: string;
   kind: AccountMailKind;
   locale: MailLocale;
   path: string;
   url?: string | undefined;
+  from?: string | undefined;
   values?: Record<string, string>;
 }): SystemMailMessage {
   return {
-    from: accountEmailFrom() ?? "",
+    from: input.from ?? accountEmailFrom() ?? "",
     to: input.to,
     ...buildAccountMail({
       kind: input.kind,

--- a/apps/web/src/server/system-mail.ts
+++ b/apps/web/src/server/system-mail.ts
@@ -5,8 +5,13 @@ import {
   isCloudDeployment,
   notificationsEmailFrom,
 } from "@millionsend/config";
-import { type SystemMailMessage, sendSystemMail } from "@millionsend/core";
-import { EMAIL_WORDMARK_URL, escapeHtml } from "@millionsend/core/html";
+import {
+  accountMailCard,
+  fillTemplate as fill,
+  type MailLocale,
+  type SystemMailMessage,
+  sendSystemMail,
+} from "@millionsend/core";
 import { type Db, getDb, schema } from "@millionsend/db";
 import { createSesSendClient, sendSimpleEmail } from "@millionsend/ses";
 import { and, eq, gt, like, ne } from "drizzle-orm";
@@ -32,7 +37,8 @@ const MESSAGES = { en, "pt-BR": ptBR } as const;
 const INVITE_MESSAGES = { en: enInvite, "pt-BR": ptBRInvite } as const;
 const VERIFY_MESSAGES = { en: enVerify, "pt-BR": ptBRVerify } as const;
 const UPDATES_MESSAGES = { en: enUpdates.email, "pt-BR": ptBRUpdates.email } as const;
-export type MailLocale = keyof typeof MESSAGES;
+
+export type { MailLocale };
 
 /**
  * Honest "this process can reach SES": explicit keys, or the operator's
@@ -65,50 +71,6 @@ export function passwordRecoveryEnabled(): boolean {
  */
 export function emailVerificationEnabled(): boolean {
   return passwordRecoveryEnabled();
-}
-
-const MUTED = 'style="font-size:13px;line-height:1.5;color:#52525b;margin:24px 0 0"';
-
-/**
- * Fills `{key}` placeholders. A replacer function, not a replacement string:
- * user-controlled values such as names may contain `$'` / `$$`, which
- * String.replace would otherwise interpret. Every occurrence is filled.
- */
-function fill(template: string, values: Record<string, string>): string {
-  return template.replace(/\{(\w+)\}/g, (match, key: string) => values[key] ?? match);
-}
-
-/**
- * The one account-mail layout: wordmark, white card, paragraphs, a button,
- * the link as text, muted footers. Everything is escaped here, so the
- * catalogs stay plain text.
- */
-function accountMailCard(input: {
-  paragraphs: string[];
-  button: string;
-  url: string;
-  linkFallback: string;
-  muted: string[];
-}): { html: string; text: string } {
-  const url = escapeHtml(input.url);
-  const paragraphs = input.paragraphs
-    .map(
-      (p) =>
-        `<p style="font-size:14px;line-height:1.5;color:#18181b;margin:0 0 12px">${escapeHtml(p)}</p>`,
-    )
-    .join("\n    ");
-  const muted = input.muted.map((m) => `<p ${MUTED}>${escapeHtml(m)}</p>`).join("\n    ");
-  const html = `<div style="background:#f4f4f5;padding:32px 16px;font-family:-apple-system,'Segoe UI',Roboto,sans-serif">
-  <div style="max-width:440px;margin:0 auto;background:#ffffff;border-radius:12px;padding:32px">
-    <img src="${EMAIL_WORDMARK_URL}" width="174" height="24" alt="MillionSend" style="display:block;height:24px;width:auto;margin:0 0 24px;border:0">
-    ${paragraphs}
-    <a href="${url}" style="display:inline-block;background:#18181b;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;border-radius:8px;padding:12px 20px;margin-top:12px">${escapeHtml(input.button)}</a>
-    <p ${MUTED}>${escapeHtml(input.linkFallback)}<br><a href="${url}" style="color:#18181b;word-break:break-all">${url}</a></p>
-    ${muted}
-  </div>
-</div>`;
-  const text = `${input.paragraphs.join("\n\n")}\n\n${input.url}\n\n${input.muted.join("\n\n")}\n`;
-  return { html, text };
 }
 
 /** Exported for tests; interpolates and escapes, so strings stay in JSON. */

--- a/apps/web/src/server/system-mail.ts
+++ b/apps/web/src/server/system-mail.ts
@@ -6,7 +6,10 @@ import {
   notificationsEmailFrom,
 } from "@millionsend/config";
 import {
+  type AccountMailKind,
   accountMailCard,
+  accountMailPhrase,
+  buildAccountMail,
   fillTemplate as fill,
   type MailLocale,
   type SystemMailMessage,
@@ -15,6 +18,8 @@ import {
 import { type Db, getDb, schema } from "@millionsend/db";
 import { createSesSendClient, sendSimpleEmail } from "@millionsend/ses";
 import { and, eq, gt, like, ne } from "drizzle-orm";
+import { appBaseUrl } from "@/lib/api-base-url";
+import { DOCS_URL } from "@/lib/docs-links";
 import enInvite from "../../messages/en/invite-email.json";
 import en from "../../messages/en/reset-email.json";
 import enUpdates from "../../messages/en/updates.json";
@@ -185,6 +190,91 @@ export function buildInvitationEmail(input: {
     }),
     kind: "invitation",
   };
+}
+
+/** One catalog kind, from the account sender, addressed to a person. */
+function accountMail(input: {
+  to: string;
+  kind: AccountMailKind;
+  locale: MailLocale;
+  path: string;
+  values?: Record<string, string>;
+}): SystemMailMessage {
+  return {
+    from: accountEmailFrom() ?? "",
+    to: input.to,
+    ...buildAccountMail({
+      kind: input.kind,
+      locale: input.locale,
+      url: `${appBaseUrl()}${input.path}`,
+      ...(input.values ? { values: input.values } : {}),
+    }),
+    kind: input.kind,
+  };
+}
+
+/** Exported for tests. Onboarding only: the first two steps and the docs. */
+export function buildWelcomeEmail(input: {
+  to: string;
+  name: string;
+  locale: MailLocale;
+}): SystemMailMessage {
+  return accountMail({
+    to: input.to,
+    kind: "welcome",
+    locale: input.locale,
+    path: "/domains",
+    values: { name: input.name, docsUrl: DOCS_URL },
+  });
+}
+
+/** Exported for tests. The button starts a new reset, which signs out whoever changed it. */
+export function buildPasswordChangedEmail(input: {
+  to: string;
+  locale: MailLocale;
+}): SystemMailMessage {
+  return accountMail({
+    to: input.to,
+    kind: "password_changed",
+    locale: input.locale,
+    path: "/forgot-password",
+    values: { email: input.to },
+  });
+}
+
+/** Exported for tests. `team` is the team's name, or every team when the grant was for all. */
+export function buildMcpConnectedEmail(input: {
+  to: string;
+  app: string;
+  team: string | "*";
+  scopes: string[];
+  locale: MailLocale;
+}): SystemMailMessage {
+  const team =
+    input.team === "*"
+      ? accountMailPhrase({ locale: input.locale, kind: "mcp.connected", key: "allTeams" })
+      : input.team;
+  return accountMail({
+    to: input.to,
+    kind: "mcp.connected",
+    locale: input.locale,
+    path: "/settings/connected-apps",
+    values: { app: input.app, team, scopes: input.scopes.join(", ") },
+  });
+}
+
+/**
+ * A mail about the account itself, sent without holding the request: the
+ * endpoint's answer must not depend on the send, and a failure is logged
+ * rather than surfaced — the account state it reports on already exists.
+ */
+export function sendAccountMail(
+  message: SystemMailMessage,
+  deps: SystemMailDeps = defaultSystemMailDeps,
+): void {
+  void deps.send(message).catch((error) => {
+    console.error(`${message.kind} email failed to send`, error);
+  });
 }
 
 /** Mail seam so tests capture sends instead of stubbing the pipeline or the AWS SDK. */

--- a/apps/web/test/billing-webhook-route.test.ts
+++ b/apps/web/test/billing-webhook-route.test.ts
@@ -1,3 +1,4 @@
+import type { SystemMailMessage } from "@millionsend/core";
 import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
 import { createTeam, createTestDb } from "@millionsend/test-utils";
@@ -9,8 +10,9 @@ const h = vi.hoisted(() => ({
   db: undefined as unknown as Db,
   runCronNow: vi.fn(async (_name: string) => {}),
   // Stands in for Stripe's subscription handling: the route only needs to see
-  // the plan column change under a verified event.
-  planAfterEvent: null as string | null,
+  // the team's billing columns change under a verified event.
+  afterEvent: null as Partial<typeof schema.teams.$inferInsert> | null,
+  sent: [] as SystemMailMessage[],
 }));
 
 vi.mock("@millionsend/db", async (importOriginal) => {
@@ -18,15 +20,19 @@ vi.mock("@millionsend/db", async (importOriginal) => {
   return { ...actual, getDb: () => h.db };
 });
 vi.mock("@/server/queue", () => ({ getQueue: async () => ({ runCronNow: h.runCronNow }) }));
+vi.mock("@/server/system-mail", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/server/system-mail")>();
+  return { ...actual, sendAccountMail: (m: SystemMailMessage) => void h.sent.push(m) };
+});
 vi.mock("@millionsend/billing", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@millionsend/billing")>();
   return {
     ...actual,
     handleWebhook: async (...args: Parameters<typeof actual.handleWebhook>) => {
-      if (!h.planAfterEvent) return actual.handleWebhook(...args);
+      if (!h.afterEvent) return actual.handleWebhook(...args);
       await h.db
         .update(schema.teams)
-        .set({ plan: h.planAfterEvent as "free" | "pro" | "scale" })
+        .set(h.afterEvent)
         .where(eq(schema.teams.stripeCustomerId, "cus_1"));
       return 200;
     },
@@ -57,6 +63,41 @@ function post(signature: string | null): Promise<Response> {
   );
 }
 
+/** A signed event for customer cus_1; `object` is merged into Stripe's data.object. */
+function send(id: string, type: string, object: Record<string, unknown> = {}): Promise<Response> {
+  const body = JSON.stringify({
+    id,
+    object: "event",
+    type,
+    livemode: false,
+    data: { object: { id: "sub_1", customer: "cus_1", ...object } },
+  });
+  return POST(
+    new Request("https://app.example.com/api/billing/webhook", {
+      method: "POST",
+      headers: new Headers({
+        "content-type": "application/json",
+        "stripe-signature": webhooks.generateTestHeaderString({ payload: body, secret: SECRET }),
+      }),
+      body,
+    }),
+  );
+}
+
+async function subscribedTeam(name = "upgrader"): Promise<string> {
+  const teamId = await createTeam(h.db, name);
+  await h.db
+    .update(schema.teams)
+    .set({ stripeCustomerId: "cus_1" })
+    .where(eq(schema.teams.id, teamId));
+  return teamId;
+}
+
+async function addOwner(teamId: string, id: string, email: string) {
+  await h.db.insert(schema.user).values({ id, name: id, email });
+  await h.db.insert(schema.teamMembers).values({ teamId, userId: id, role: "owner" });
+}
+
 let close: () => Promise<void>;
 
 beforeEach(async () => {
@@ -64,11 +105,13 @@ beforeEach(async () => {
   vi.stubEnv("IS_CLOUD", "true");
   vi.stubEnv("STRIPE_SECRET_KEY", "sk_test_x");
   vi.stubEnv("STRIPE_WEBHOOK_SECRET", SECRET);
+  vi.stubEnv("APP_BASE_URL", "https://app.example.com");
 });
 
 afterEach(async () => {
   vi.unstubAllEnvs();
-  h.planAfterEvent = null;
+  h.afterEvent = null;
+  h.sent = [];
   h.runCronNow.mockClear();
   await close();
 });
@@ -90,54 +133,25 @@ describe("POST /api/billing/webhook", () => {
   });
 
   it("drains quota-parked mail at once when an event raises the team's plan", async () => {
-    const teamId = await createTeam(h.db, "upgrader");
-    await h.db
-      .update(schema.teams)
-      .set({ stripeCustomerId: "cus_1" })
-      .where(eq(schema.teams.id, teamId));
-    // Subscription events carry the customer id, which is how the route
-    // finds the team whose plan may have moved.
-    const subscriptionEvent = (id: string) =>
-      JSON.stringify({
-        id,
-        object: "event",
-        type: "customer.subscription.updated",
-        livemode: false,
-        data: { object: { id: "sub_1", customer: "cus_1" } },
-      });
-    const send = (body: string) =>
-      POST(
-        new Request("https://app.example.com/api/billing/webhook", {
-          method: "POST",
-          headers: new Headers({
-            "content-type": "application/json",
-            "stripe-signature": webhooks.generateTestHeaderString({
-              payload: body,
-              secret: SECRET,
-            }),
-          }),
-          body,
-        }),
-      );
-
-    h.planAfterEvent = "pro";
-    expect((await send(subscriptionEvent("evt_up"))).status).toBe(200);
+    await subscribedTeam();
+    h.afterEvent = { plan: "pro" };
+    expect((await send("evt_up", "customer.subscription.updated")).status).toBe(200);
     expect(h.runCronNow).toHaveBeenCalledWith("quota.drain");
 
     // A queue hiccup never fails the webhook: the plan is committed and the
     // scheduled drain releases the mail anyway.
     h.runCronNow.mockClear();
     h.runCronNow.mockRejectedValueOnce(new Error("pg-boss unavailable"));
-    h.planAfterEvent = "scale";
+    h.afterEvent = { plan: "scale" };
     const errors = vi.spyOn(console, "error").mockImplementation(() => {});
-    expect((await send(subscriptionEvent("evt_up2"))).status).toBe(200);
+    expect((await send("evt_up2", "customer.subscription.updated")).status).toBe(200);
     expect(h.runCronNow).toHaveBeenCalledTimes(1);
     errors.mockRestore();
 
     // A downgrade leaves the schedule alone.
     h.runCronNow.mockClear();
-    h.planAfterEvent = "free";
-    expect((await send(subscriptionEvent("evt_down"))).status).toBe(200);
+    h.afterEvent = { plan: "free" };
+    expect((await send("evt_down", "customer.subscription.updated")).status).toBe(200);
     expect(h.runCronNow).not.toHaveBeenCalled();
   });
 
@@ -148,5 +162,144 @@ describe("POST /api/billing/webhook", () => {
     expect(await h.db.select({ id: schema.stripeEvents.id }).from(schema.stripeEvents)).toEqual([
       { id: "evt_1" },
     ]);
+  });
+});
+
+describe("owner mail", () => {
+  const PERIOD_END = new Date("2026-09-30T12:00:00Z");
+  let teamId: string;
+
+  beforeEach(async () => {
+    vi.stubEnv("AUTH_EMAIL_FROM", "MillionSend <account@mail.example.com>");
+    teamId = await subscribedTeam();
+    await addOwner(teamId, "ada", "ada@example.com");
+    // A plain member hears nothing about billing.
+    await h.db.insert(schema.user).values({ id: "cid", name: "cid", email: "cid@example.com" });
+    await h.db.insert(schema.teamMembers).values({ teamId, userId: "cid", role: "member" });
+  });
+
+  const kinds = () => h.sent.map((m) => m.kind);
+
+  it("says nothing without an account sender", async () => {
+    vi.stubEnv("AUTH_EMAIL_FROM", "");
+    h.afterEvent = { plan: "pro" };
+    await send("evt_1", "customer.subscription.updated");
+    expect(h.sent).toEqual([]);
+  });
+
+  it("reports an activation once, however often Stripe delivers the event", async () => {
+    h.afterEvent = { plan: "pro", currentPeriodEnd: PERIOD_END };
+    await send("evt_1", "customer.subscription.updated");
+    await send("evt_1", "customer.subscription.updated");
+    await send("evt_2", "invoice.paid", { id: "in_1" });
+    expect(kinds()).toEqual(["billing.plan_activated"]);
+    expect(h.sent[0]).toMatchObject({ to: "ada@example.com", subject: "upgrader is on Pro" });
+    expect(h.sent[0]?.text).toContain("up to 3,000 emails a day");
+    expect(h.sent[0]?.text).toContain("https://app.example.com/settings/billing");
+  });
+
+  it("reports a move between paid plans with the new cap", async () => {
+    h.afterEvent = { plan: "pro", currentPeriodEnd: PERIOD_END };
+    await send("evt_1", "customer.subscription.updated");
+    h.afterEvent = { plan: "scale" };
+    await send("evt_2", "customer.subscription.updated");
+    expect(kinds()).toEqual(["billing.plan_activated", "billing.plan_changed"]);
+    expect(h.sent[1]?.subject).toBe("upgrader moved from Pro to Scale");
+    expect(h.sent[1]?.text).toContain("with no daily cap");
+  });
+
+  it("reports a failed charge once per attempt, with Stripe's next try or the lack of one", async () => {
+    await h.db.update(schema.teams).set({ plan: "pro" }).where(eq(schema.teams.id, teamId));
+    const failed = (id: string, attempt: number, next: number | null) =>
+      send(id, "invoice.payment_failed", {
+        id: "in_1",
+        attempt_count: attempt,
+        next_payment_attempt: next,
+        hosted_invoice_url: "https://invoice.stripe.com/i/in_1",
+      });
+    h.afterEvent = { planStatus: "past_due" };
+    await failed("evt_1", 1, Date.UTC(2026, 9, 3) / 1000);
+    await failed("evt_1", 1, Date.UTC(2026, 9, 3) / 1000);
+    expect(kinds()).toEqual(["billing.payment_failed"]);
+    expect(h.sent[0]?.subject).toBe("Payment failed for upgrader's Pro plan");
+    expect(h.sent[0]?.text).toContain("Stripe retries on October 3, 2026.");
+    expect(h.sent[0]?.text).toContain("Pay the invoice: https://invoice.stripe.com/i/in_1");
+    expect(h.sent[0]?.text).toContain("https://app.example.com/settings/billing");
+
+    await failed("evt_2", 2, null);
+    expect(kinds()).toEqual(["billing.payment_failed", "billing.payment_failed"]);
+    expect(h.sent[1]?.text).toContain("Stripe is not retrying on its own.");
+
+    // A first checkout that fails never had a plan to lose: no receipt.
+    await h.db
+      .update(schema.teams)
+      .set({ plan: "free", planStatus: "incomplete" })
+      .where(eq(schema.teams.id, teamId));
+    h.afterEvent = { planStatus: "incomplete" };
+    await send("evt_3", "invoice.payment_failed", { id: "in_2", attempt_count: 1 });
+    expect(kinds()).toHaveLength(2);
+  });
+
+  it("reports a scheduled cancellation once, and an immediate one as the downgrade only", async () => {
+    await h.db
+      .update(schema.teams)
+      .set({ plan: "pro", currentPeriodEnd: PERIOD_END })
+      .where(eq(schema.teams.id, teamId));
+    h.afterEvent = { cancelAt: PERIOD_END };
+    await send("evt_1", "customer.subscription.updated");
+    await send("evt_2", "customer.subscription.updated");
+    expect(kinds()).toEqual(["billing.cancel_scheduled"]);
+    expect(h.sent[0]?.subject).toBe("Your Pro plan ends on September 30, 2026");
+    expect(h.sent[0]?.text).toContain("Free (100 emails a day)");
+
+    // Resuming is the customer's own doing: nothing to tell them.
+    h.afterEvent = { cancelAt: null };
+    await send("evt_3", "customer.subscription.updated");
+    expect(kinds()).toHaveLength(1);
+
+    h.afterEvent = { plan: "free", planStatus: "canceled", cancelAt: PERIOD_END };
+    await send("evt_4", "customer.subscription.deleted");
+    expect(kinds()).toEqual(["billing.cancel_scheduled", "billing.downgraded"]);
+    expect(h.sent[1]?.subject).toBe("upgrader is now on Free");
+    expect(h.sent[1]?.text).toContain("The Pro plan ended on September 30, 2026.");
+  });
+
+  it("claims a downgrade by the period that ended, so the sweep's own report stays silent", async () => {
+    await h.db
+      .update(schema.teams)
+      .set({ plan: "scale", currentPeriodEnd: PERIOD_END })
+      .where(eq(schema.teams.id, teamId));
+    h.afterEvent = { plan: "free", currentPeriodEnd: null };
+    await send("evt_1", "customer.subscription.deleted");
+    await send("evt_1", "customer.subscription.deleted");
+    expect(kinds()).toEqual(["billing.downgraded"]);
+    expect(
+      await h.db
+        .select({ kind: schema.teamNotifications.kind, key: schema.teamNotifications.periodKey })
+        .from(schema.teamNotifications),
+    ).toEqual([{ kind: "billing.downgraded", key: PERIOD_END.toISOString() }]);
+  });
+
+  it("writes each owner in the language of their account contact", async () => {
+    await addOwner(teamId, "bia", "bia@example.com");
+    const home = await createTeam(h.db, "home");
+    await h.db.insert(schema.domains).values({
+      teamId: home,
+      name: "mail.example.com",
+      region: "us-east-1",
+      status: "verified",
+    });
+    await h.db
+      .insert(schema.contacts)
+      .values({ teamId: home, email: "bia@example.com", properties: { locale: "pt-BR" } });
+    h.afterEvent = { plan: "pro" };
+    await send("evt_1", "customer.subscription.updated");
+    expect(h.sent.map((m) => [m.to, m.subject]).sort()).toEqual([
+      ["ada@example.com", "upgrader is on Pro"],
+      ["bia@example.com", "upgrader está no plano Pro"],
+    ]);
+    expect(h.sent.find((m) => m.to === "bia@example.com")?.text).toContain(
+      "até 3.000 e-mails por dia",
+    );
   });
 });

--- a/apps/web/test/billing-webhook-route.test.ts
+++ b/apps/web/test/billing-webhook-route.test.ts
@@ -1,4 +1,4 @@
-import type { SystemMailMessage } from "@millionsend/core";
+import { formatMailDate, type SystemMailMessage } from "@millionsend/core";
 import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
 import { createTeam, createTestDb } from "@millionsend/test-utils";
@@ -187,13 +187,23 @@ describe("owner mail", () => {
     expect(h.sent).toEqual([]);
   });
 
-  it("reports an activation once, however often Stripe delivers the event", async () => {
+  it("reports an activation once, however often and however parallel Stripe delivers the events", async () => {
+    vi.stubEnv("NOTIFICATIONS_EMAIL_FROM", "MillionSend <notices@mail.example.com>");
     h.afterEvent = { plan: "pro", currentPeriodEnd: PERIOD_END };
-    await send("evt_1", "customer.subscription.updated");
-    await send("evt_1", "customer.subscription.updated");
-    await send("evt_2", "invoice.paid", { id: "in_1" });
+    // A checkout's three events arrive together; each request snapshots the
+    // free plan before any of them is applied.
+    await Promise.all([
+      send("evt_1", "checkout.session.completed", { id: "cs_1" }),
+      send("evt_2", "customer.subscription.created"),
+      send("evt_3", "invoice.paid", { id: "in_1" }),
+    ]);
+    await send("evt_2", "customer.subscription.created");
     expect(kinds()).toEqual(["billing.plan_activated"]);
-    expect(h.sent[0]).toMatchObject({ to: "ada@example.com", subject: "upgrader is on Pro" });
+    expect(h.sent[0]).toMatchObject({
+      from: "MillionSend <notices@mail.example.com>",
+      to: "ada@example.com",
+      subject: "upgrader is on Pro",
+    });
     expect(h.sent[0]?.text).toContain("up to 3,000 emails a day");
     expect(h.sent[0]?.text).toContain("https://app.example.com/settings/billing");
   });
@@ -252,16 +262,45 @@ describe("owner mail", () => {
     expect(h.sent[0]?.subject).toBe("Your Pro plan ends on September 30, 2026");
     expect(h.sent[0]?.text).toContain("Free (100 emails a day)");
 
-    // Resuming is the customer's own doing: nothing to tell them.
+    // Resuming is the customer's own doing: nothing to tell them, and the
+    // same date scheduled again later is news again.
     h.afterEvent = { cancelAt: null };
     await send("evt_3", "customer.subscription.updated");
     expect(kinds()).toHaveLength(1);
+    h.afterEvent = { cancelAt: PERIOD_END };
+    await send("evt_3b", "customer.subscription.updated");
+    expect(kinds()).toEqual(["billing.cancel_scheduled", "billing.cancel_scheduled"]);
+    h.afterEvent = { cancelAt: null };
+    await send("evt_3c", "customer.subscription.updated");
 
+    // Cancelled now: the plan ended today, not at the period end it never reached.
     h.afterEvent = { plan: "free", planStatus: "canceled", cancelAt: PERIOD_END };
     await send("evt_4", "customer.subscription.deleted");
-    expect(kinds()).toEqual(["billing.cancel_scheduled", "billing.downgraded"]);
-    expect(h.sent[1]?.subject).toBe("upgrader is now on Free");
-    expect(h.sent[1]?.text).toContain("The Pro plan ended on September 30, 2026.");
+    expect(kinds()).toEqual([
+      "billing.cancel_scheduled",
+      "billing.cancel_scheduled",
+      "billing.downgraded",
+    ]);
+    expect(h.sent[2]?.subject).toBe("upgrader is now on Free");
+    expect(h.sent[2]?.text).toContain(`The Pro plan ended on ${formatMailDate("en", new Date())}.`);
+  });
+
+  it("a cancellation scheduled inside the reminder window is its own reminder", async () => {
+    await h.db.update(schema.teams).set({ plan: "pro" }).where(eq(schema.teams.id, teamId));
+    const soon = new Date(Date.now() + 2 * 86_400_000);
+    h.afterEvent = { cancelAt: soon };
+    await send("evt_1", "customer.subscription.updated");
+    expect(kinds()).toEqual(["billing.cancel_scheduled"]);
+    expect(
+      (
+        await h.db
+          .select({ kind: schema.teamNotifications.kind, key: schema.teamNotifications.periodKey })
+          .from(schema.teamNotifications)
+      ).sort((a, b) => a.kind.localeCompare(b.kind)),
+    ).toEqual([
+      { kind: "billing.cancel_reminder", key: soon.toISOString() },
+      { kind: "billing.cancel_scheduled", key: soon.toISOString() },
+    ]);
   });
 
   it("claims a downgrade by the period that ended, so the sweep's own report stays silent", async () => {

--- a/apps/web/test/email-verification.test.ts
+++ b/apps/web/test/email-verification.test.ts
@@ -84,10 +84,9 @@ describe("email verification", () => {
     await expect(signIn(a)).rejects.toMatchObject({ status: "FORBIDDEN" });
     expect(sent).toHaveLength(2);
 
-    await a.api.verifyEmail({
-      query: { token: url.searchParams.get("token") ?? "" },
-      headers: new Headers({ "accept-language": "pt-BR" }),
-    });
+    // Over HTTP, as the browser opens the link: the welcome reads its language.
+    const opened = await a.handler(new Request(url, { headers: { "accept-language": "pt-BR" } }));
+    expect(opened.status).toBe(302);
     const [user] = await db
       .select({ verified: schema.user.emailVerified })
       .from(schema.user)
@@ -100,7 +99,7 @@ describe("email verification", () => {
       "email_verification",
       "welcome",
     ]);
-    expect(sent[2]).toMatchObject({ to: "ada@example.com", subject: "Welcome to MillionSend" });
+    expect(sent[2]).toMatchObject({ to: "ada@example.com", subject: "Bem-vindo ao MillionSend" });
     expect((await signIn(a)).token).toBeTruthy();
     expect(sent).toHaveLength(3);
   });

--- a/apps/web/test/email-verification.test.ts
+++ b/apps/web/test/email-verification.test.ts
@@ -84,13 +84,25 @@ describe("email verification", () => {
     await expect(signIn(a)).rejects.toMatchObject({ status: "FORBIDDEN" });
     expect(sent).toHaveLength(2);
 
-    await a.api.verifyEmail({ query: { token: url.searchParams.get("token") ?? "" } });
+    await a.api.verifyEmail({
+      query: { token: url.searchParams.get("token") ?? "" },
+      headers: new Headers({ "accept-language": "pt-BR" }),
+    });
     const [user] = await db
       .select({ verified: schema.user.emailVerified })
       .from(schema.user)
       .where(eq(schema.user.email, "ada@example.com"));
     expect(user?.verified).toBe(true);
+    // The welcome waits for the address to be its owner's, then follows the
+    // language of the request that opened the link.
+    expect(sent.map((m) => m.kind)).toEqual([
+      "email_verification",
+      "email_verification",
+      "welcome",
+    ]);
+    expect(sent[2]).toMatchObject({ to: "ada@example.com", subject: "Welcome to MillionSend" });
     expect((await signIn(a)).token).toBeTruthy();
+    expect(sent).toHaveLength(3);
   });
 
   it("an account from before verification existed is asked at its next sign-in", async () => {

--- a/apps/web/test/mail-preferences.test.ts
+++ b/apps/web/test/mail-preferences.test.ts
@@ -1,0 +1,35 @@
+import type { Db } from "@millionsend/db";
+import { schema } from "@millionsend/db";
+import { createTeam, createTestDb } from "@millionsend/test-utils";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { createCaller } from "@/server/routers";
+
+let db: Db;
+let close: () => Promise<void>;
+
+beforeEach(async () => {
+  ({ db, close } = await createTestDb());
+  await db.insert(schema.user).values({ id: "u1", name: "u1", email: "u1@example.com" });
+});
+afterEach(() => close());
+
+it("every notice starts on; a switch turned off twice is off once, and turning it back on leaves the others", async () => {
+  const teamId = await createTeam(db, "acme");
+  const caller = createCaller({
+    db,
+    session: { user: { id: "u1", email: "u1@example.com", name: "u1" } },
+    teamId,
+    role: "owner",
+  });
+  const prefs = caller.settings.mailPreferences;
+  expect(await prefs.get()).toEqual({ optOuts: [] });
+  expect(await prefs.set({ key: "broadcast.sent", enabled: false })).toEqual({
+    optOuts: ["broadcast.sent"],
+  });
+  await prefs.set({ key: "broadcast.sent", enabled: false });
+  await prefs.set({ key: "quota", enabled: false });
+  expect((await prefs.get()).optOuts.sort()).toEqual(["broadcast.sent", "quota"]);
+  expect(await prefs.set({ key: "broadcast.sent", enabled: true })).toEqual({ optOuts: ["quota"] });
+  // Mail that is always sent has no switch to turn.
+  await expect(prefs.set({ key: "api_key.created" as never, enabled: false })).rejects.toBeTruthy();
+});

--- a/apps/web/test/oauth-provider.test.ts
+++ b/apps/web/test/oauth-provider.test.ts
@@ -1,4 +1,5 @@
 import { createHash, createPublicKey, type JsonWebKey, randomBytes, verify } from "node:crypto";
+import type { SystemMailMessage } from "@millionsend/core";
 import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
 import { createTeam, createTestDb } from "@millionsend/test-utils";
@@ -18,13 +19,15 @@ const RESOURCE_SCOPE = "emails:send audience:read";
 let db: Db;
 let close: () => Promise<void>;
 let auth: Auth;
+let sent: SystemMailMessage[];
 
 beforeEach(async () => {
   vi.stubEnv("BETTER_AUTH_SECRET", "test-secret-test-secret-test-secret-1234");
   vi.stubEnv("APP_BASE_URL", BASE);
   vi.stubEnv("ALLOW_SIGNUP", "true");
   ({ db, close } = await createTestDb());
-  auth = createAuth(db);
+  sent = [];
+  auth = createAuth(db, { send: async (m) => void sent.push(m) });
 });
 
 afterEach(async () => {
@@ -111,7 +114,12 @@ async function clientRow(clientId: string) {
 }
 
 /** Authorization-code + PKCE round trip as an MCP client would run it. */
-async function authorize(clientId: string, cookie: string, consentScope?: string) {
+async function authorize(
+  clientId: string,
+  cookie: string,
+  consentScope?: string,
+  prompt?: "consent",
+) {
   const verifier = randomBytes(32).toString("base64url");
   const challenge = createHash("sha256").update(verifier).digest("base64url");
   const query = new URLSearchParams({
@@ -123,6 +131,7 @@ async function authorize(clientId: string, cookie: string, consentScope?: string
     code_challenge: challenge,
     code_challenge_method: "S256",
     resource: RESOURCE,
+    ...(prompt ? { prompt } : {}),
   });
   const authorizeRes = await call(`/oauth2/authorize?${query}`, { cookie });
   const consentUrl = new URL(await redirectTarget(authorizeRes), BASE);
@@ -670,5 +679,31 @@ describe("OAuth authorization server", () => {
     } finally {
       auth = prior;
     }
+  });
+});
+
+describe("connected-app receipt", () => {
+  it("mails the granting user once per fresh consent, naming the app, the team and the scopes", async () => {
+    vi.stubEnv("AUTH_EMAIL_FROM", "MillionSend <no-reply@mail.example.com>");
+    const { userId, cookie } = await signUp("ada@example.com");
+    const teamId = await createTeam(db, "acme");
+    await addMember(userId, teamId);
+    const clientId = await registerClient();
+    sent.length = 0;
+    await authorize(clientId, cookie);
+    expect(sent.map((m) => m.kind)).toEqual(["mcp.connected"]);
+    expect(sent[0]).toMatchObject({ to: "ada@example.com" });
+    expect(sent[0]?.subject).toContain("Claude Code");
+    expect(sent[0]?.text).toContain("emails:send");
+    expect(sent[0]?.text).toContain("/settings/connected-apps");
+    // Granting the same app again later (prompt=consent brings the screen
+    // back) updates the stored consent: a repeat, not news. The provider
+    // stamps consents to the second, so the first one is aged past that.
+    await db
+      .update(schema.oauthConsent)
+      .set({ createdAt: new Date(Date.now() - 5_000) })
+      .where(eq(schema.oauthConsent.clientId, clientId));
+    await authorize(clientId, cookie, undefined, "consent");
+    expect(sent).toHaveLength(1);
   });
 });

--- a/apps/web/test/password-reset.test.ts
+++ b/apps/web/test/password-reset.test.ts
@@ -1,3 +1,4 @@
+import type { SystemMailMessage } from "@millionsend/core";
 import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
 import type { SimpleEmail } from "@millionsend/ses";
@@ -212,6 +213,51 @@ describe("request-password-reset endpoint", () => {
       expect(sent).toHaveLength(1);
       expect(sent[0]?.to).toBe("ada@example.com");
       expect(sent[0]?.html).toContain("/reset-password/");
+    } finally {
+      await close();
+    }
+  });
+});
+
+describe("password changed receipt", () => {
+  it("follows a completed reset and points at a fresh reset, never a bad token", async () => {
+    stubRecoveryEnv();
+    vi.stubEnv("BETTER_AUTH_SECRET", "test-secret-test-secret-test-secret-1234");
+    vi.stubEnv("APP_BASE_URL", "http://localhost:3000");
+    vi.stubEnv("ALLOW_SIGNUP", "true");
+    const { db, close } = await createTestDb();
+    try {
+      const sent: SystemMailMessage[] = [];
+      const auth = createAuth(db, { send: async (m) => void sent.push(m) });
+      await auth.api.signUpEmail({
+        body: { name: "Ada", email: "ada@example.com", password: "correct horse battery" },
+      });
+      sent.length = 0;
+      await auth.api.requestPasswordReset({ body: { email: "ada@example.com", redirectTo: "/x" } });
+      const token = sent[0]?.text.match(/reset-password\/([^?\s]+)/)?.[1] ?? "";
+      await expect(
+        auth.api.resetPassword({ body: { newPassword: "another horse battery", token: "nope" } }),
+      ).rejects.toBeTruthy();
+      expect(sent.map((m) => m.kind)).toEqual(["password_reset"]);
+      // Over HTTP, as the browser does it: the receipt reads the request's language.
+      const reset = await auth.handler(
+        new Request("http://localhost:3000/api/auth/reset-password", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            origin: "http://localhost:3000",
+            "accept-language": "pt-BR",
+          },
+          body: JSON.stringify({ newPassword: "another horse battery", token }),
+        }),
+      );
+      expect(reset.status).toBe(200);
+      expect(sent.map((m) => m.kind)).toEqual(["password_reset", "password_changed"]);
+      expect(sent[1]).toMatchObject({
+        to: "ada@example.com",
+        subject: "Sua senha do MillionSend foi alterada",
+      });
+      expect(sent[1]?.text).toContain("http://localhost:3000/forgot-password");
     } finally {
       await close();
     }

--- a/apps/web/test/system-contacts.test.ts
+++ b/apps/web/test/system-contacts.test.ts
@@ -16,6 +16,8 @@ import { type Auth, createAuth } from "@/server/auth";
 let db: Db;
 let close: () => Promise<void>;
 let teamId: string;
+let sends: SystemMailMessage[];
+const seam = { send: async (message: SystemMailMessage) => void sends.push(message) };
 const keyring = EnvKeyring.fromBase64(randomBytes(32).toString("base64"));
 
 beforeEach(async () => {
@@ -29,6 +31,7 @@ beforeEach(async () => {
   vi.stubEnv("AWS_SECRET_ACCESS_KEY", "");
   vi.stubEnv("AWS_DEFAULT_CHAIN", "");
   ({ db, close } = await createTestDb());
+  sends = [];
   teamId = await createTeam(db, "owner");
   await db.insert(schema.domains).values({
     teamId,
@@ -60,23 +63,38 @@ const contactsOf = (email: string) =>
   db.select().from(schema.contacts).where(eq(schema.contacts.email, email));
 
 describe("enrollment and the sign-up flag", () => {
-  it("a self-host closed to sign-up enrolls nobody", async () => {
+  it("a self-host closed to sign-up enrolls nobody, but still welcomes the account it admits", async () => {
     vi.stubEnv("ALLOW_SIGNUP", "false");
-    await signUp(createAuth(db), "first@example.com");
+    await signUp(createAuth(db, seam), "first@example.com");
     expect(await contactsOf("first@example.com")).toEqual([]);
+    expect(sends.map((m) => [m.kind, m.to])).toEqual([["welcome", "first@example.com"]]);
+  });
+
+  it("welcomes once, in the sign-up request's language, with the docs and the domains page", async () => {
+    await signUp(createAuth(db, seam), "ada@example.com");
+    expect(sends).toHaveLength(1);
+    expect(sends[0]).toMatchObject({
+      kind: "welcome",
+      to: "ada@example.com",
+      from: "MillionSend <no-reply@mail.example.com>",
+      subject: "Bem-vindo ao MillionSend",
+    });
+    expect(sends[0]?.text).toContain("Olá, Ada Lovelace");
+    expect(sends[0]?.text).toContain("http://localhost:3000/domains");
+    expect(sends[0]?.text).toContain("https://docs.millionsend.com");
   });
 
   it("the cloud enrolls whatever the flag says", async () => {
     vi.stubEnv("ALLOW_SIGNUP", "false");
     vi.stubEnv("IS_CLOUD", "true");
-    await signUp(createAuth(db), "first@example.com");
+    await signUp(createAuth(db, seam), "first@example.com");
     expect(await contactsOf("first@example.com")).toHaveLength(1);
   });
 });
 
 describe("accounts as contacts of the account-mail team", () => {
   it("a sign-up becomes a contact with its name split and its provenance stamped", async () => {
-    await signUp(createAuth(db), "ada@example.com");
+    await signUp(createAuth(db, seam), "ada@example.com");
     const [contact] = await contactsOf("ada@example.com");
     expect(contact).toMatchObject({
       teamId,
@@ -95,13 +113,13 @@ describe("accounts as contacts of the account-mail team", () => {
 
   it("a closed instance enrolls nobody", async () => {
     vi.stubEnv("ALLOW_SIGNUP", "false");
-    await signUp(createAuth(db), "first@example.com");
+    await signUp(createAuth(db, seam), "first@example.com");
     expect(await contactsOf("first@example.com")).toHaveLength(0);
   });
 
   it("without a team owning the sender's domain, nothing is enrolled", async () => {
     vi.stubEnv("AUTH_EMAIL_FROM", "no-reply@unowned.example.com");
-    await signUp(createAuth(db), "ada@example.com");
+    await signUp(createAuth(db, seam), "ada@example.com");
     expect(await contactsOf("ada@example.com")).toHaveLength(0);
   });
 
@@ -112,7 +130,7 @@ describe("accounts as contacts of the account-mail team", () => {
       unsubscribed: true,
       properties: { source: "import" },
     });
-    await signUp(createAuth(db), "ada@example.com");
+    await signUp(createAuth(db, seam), "ada@example.com");
     const rows = await db.select().from(schema.contacts).where(eq(schema.contacts.teamId, teamId));
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({ unsubscribed: true, properties: { source: "import" } });
@@ -135,7 +153,7 @@ describe("accounts as contacts of the account-mail team", () => {
   });
 
   it("deleting the account removes the contact and scrubs the address from the team's log", async () => {
-    const auth = createAuth(db, undefined, {
+    const auth = createAuth(db, seam, {
       eraseRecipient: (teamId, address) => eraseRecipient(db, teamId, address),
     });
     const { cookie } = await signUp(auth, "ada@example.com");

--- a/apps/worker/src/handlers/cron.ts
+++ b/apps/worker/src/handlers/cron.ts
@@ -6,6 +6,7 @@ import {
   getInstanceSettings,
   isIdentitySharedByOtherDomains,
   PLAN_DAILY_LIMIT,
+  type PlanSnapshot,
   purgedEmailBodyColumns,
   recordAudit,
   releaseDailyQuota,
@@ -971,14 +972,30 @@ export async function purgeExpiredSessions(db: Db, now = new Date()): Promise<nu
 /**
  * Daily plan reconcile against Stripe for every team with a customer: covers
  * webhooks that were dropped or arrived out of order. One team's failure is
- * logged and never blocks the rest.
+ * logged and never blocks the rest. A plan the reconcile moved is reported
+ * through `onPlanMoved`, since the webhook that would have said so never
+ * came (or will find nothing left to say when it does).
  */
 export async function reconcileBillingPlans(
   db: Db,
-  deps: { reconcileTeam: (teamId: string) => Promise<void> },
+  deps: {
+    reconcileTeam: (teamId: string) => Promise<void>;
+    onPlanMoved?: (
+      team: { id: string; name: string },
+      before: PlanSnapshot,
+      after: PlanSnapshot,
+    ) => Promise<void>;
+  },
 ): Promise<{ reconciled: number; failed: number }> {
+  const columns = {
+    id: schema.teams.id,
+    name: schema.teams.name,
+    plan: schema.teams.plan,
+    currentPeriodEnd: schema.teams.currentPeriodEnd,
+    cancelAt: schema.teams.cancelAt,
+  };
   const teams = await db
-    .select({ id: schema.teams.id })
+    .select(columns)
     .from(schema.teams)
     .where(isNotNull(schema.teams.stripeCustomerId))
     .orderBy(asc(schema.teams.id));
@@ -986,6 +1003,13 @@ export async function reconcileBillingPlans(
   for (const team of teams) {
     try {
       await deps.reconcileTeam(team.id);
+      if (deps.onPlanMoved) {
+        const [after] = await db
+          .select(columns)
+          .from(schema.teams)
+          .where(eq(schema.teams.id, team.id));
+        if (after && after.plan !== team.plan) await deps.onPlanMoved(team, team, after);
+      }
     } catch (err) {
       failed += 1;
       console.warn(`billing.reconcile: team ${team.id} failed`, err);

--- a/apps/worker/src/handlers/notify.ts
+++ b/apps/worker/src/handlers/notify.ts
@@ -4,6 +4,7 @@ import {
   accountLocale,
   accountMailPhrase,
   buildAccountMail,
+  CANCEL_REMINDER_DAYS,
   claimNotification,
   clearNotifications,
   DAY_MS,
@@ -19,8 +20,10 @@ import {
   PAUSE_COMPLAINT_RATE,
   PLAN_DAILY_LIMIT,
   PLAN_NAME,
+  type PlanSnapshot,
   parseAuditActor,
   planCapPhrase,
+  planMove,
   QUOTA_TOLERANCE,
   resultRows,
   type SystemMailKind,
@@ -72,8 +75,6 @@ export interface NotifyDeps {
 
 /** Share of the daily quota at which owners hear about it. */
 export const QUOTA_WARNING_RATIO = 0.8;
-/** Days ahead of a scheduled cancellation at which owners are reminded. */
-export const CANCEL_REMINDER_DAYS = 3;
 /** Audit actions owners hear about; rows older than a day are never read. */
 const AUDIT_MAILED = ["api_key.created", "webhook.secret_rotated", "member.joined"] as const;
 type AuditMailed = (typeof AUDIT_MAILED)[number];
@@ -167,6 +168,39 @@ const lineFor = (r: DeliverabilityReason): number =>
     : r.metric === "bounce"
       ? WARN_BOUNCE_RATE
       : WARN_COMPLAINT_RATE;
+
+/**
+ * Mails a plan move to the team's owners, claimed with the key the Stripe
+ * webhook route computes for the same move, so whichever surface notices
+ * first (the route, the daily reconcile, the grace sweep) is the one that
+ * speaks. True when it did.
+ */
+export async function reportPlanMove(
+  db: Db,
+  mailer: SystemMailer,
+  base: string,
+  team: { id: string; name: string },
+  before: PlanSnapshot,
+  after: PlanSnapshot,
+): Promise<boolean> {
+  const move = planMove(before, after);
+  if (!move) return false;
+  const claimed = await claimNotification(db, {
+    teamId: team.id,
+    kind: move.kind,
+    periodKey: move.periodKey,
+  });
+  if (!claimed) return false;
+  await mailTeamOwners(db, mailer, team.id, move.kind, (locale) =>
+    buildAccountMail({
+      kind: move.kind,
+      locale,
+      url: `${base}/settings/billing`,
+      values: move.values(locale, team.name),
+    }),
+  );
+  return true;
+}
 
 /**
  * One pass over every team's standing: quota (cloud only) and deliverability.
@@ -522,7 +556,12 @@ export async function sweepNotifications(db: Db, deps: NotifyDeps): Promise<{ se
         actor.kind === "user"
           ? (
               await db
-                .select({ name: schema.user.name, email: schema.user.email })
+                .select({
+                  name: schema.user.name,
+                  email: schema.user.email,
+                  // Still a member: someone removed since must not learn the key's prefix and last four.
+                  member: sql<boolean>`exists (select 1 from ${schema.teamMembers} where ${schema.teamMembers.teamId} = ${row.teamId} and ${schema.teamMembers.userId} = ${actor.id})`,
+                })
                 .from(schema.user)
                 .where(eq(schema.user.id, actor.id))
             )[0]
@@ -577,7 +616,7 @@ export async function sweepNotifications(db: Db, deps: NotifyDeps): Promise<{ se
                 })
               : "",
           })),
-          actorUser
+          actorUser?.member
             ? {
                 also: {
                   email: actorUser.email,
@@ -604,8 +643,13 @@ export async function sweepNotifications(db: Db, deps: NotifyDeps): Promise<{ se
             actor: actorLabel(locale),
             url,
             host,
-            until: expires
-              ? formatMailDateTime(locale, expires)
+            deadline: expires
+              ? accountMailPhrase({
+                  locale,
+                  kind: action,
+                  key: "overlap",
+                  values: { until: formatMailDateTime(locale, expires) },
+                })
               : accountMailPhrase({ locale, kind: action, key: "immediately" }),
           })),
         );
@@ -671,26 +715,12 @@ export async function sweepNotifications(db: Db, deps: NotifyDeps): Promise<{ se
           })),
         );
       }
-      const periodEnd = t.currentPeriodEnd;
       if (
-        periodEnd &&
-        effectivePlan(t.plan, periodEnd, now) === "free" &&
-        (await claimNotification(db, {
-          teamId: t.id,
-          kind: "billing.downgraded",
-          periodKey: periodEnd.toISOString(),
-        }))
+        t.currentPeriodEnd &&
+        effectivePlan(t.plan, t.currentPeriodEnd, now) === "free" &&
+        (await reportPlanMove(db, deps.mailer, base, t, t, { ...t, plan: "free" }))
       ) {
-        await mailOwners(
-          t.id,
-          "billing.downgraded",
-          account("billing.downgraded", "/settings/billing", (locale) => ({
-            team: t.name,
-            plan: PLAN_NAME[t.plan],
-            date: formatMailDate(locale, periodEnd),
-            freeCap: freeCap(locale),
-          })),
-        );
+        sent += 1;
       }
     }
   }

--- a/apps/worker/src/handlers/notify.ts
+++ b/apps/worker/src/handlers/notify.ts
@@ -1,4 +1,9 @@
+import { accountEmailFrom } from "@millionsend/config";
 import {
+  type AccountMailKind,
+  accountLocale,
+  accountMailPhrase,
+  buildAccountMail,
   claimNotification,
   clearNotifications,
   DAY_MS,
@@ -6,13 +11,19 @@ import {
   effectivePlan,
   enqueueTeamWebhookDeliveries,
   fetchDeliverabilityHealth,
-  listTeamOwners,
+  formatMailDate,
+  formatMailDateTime,
+  type MailLocale,
   nextUtcDayStart,
   PAUSE_BOUNCE_RATE,
   PAUSE_COMPLAINT_RATE,
   PLAN_DAILY_LIMIT,
+  PLAN_NAME,
+  parseAuditActor,
+  planCapPhrase,
   QUOTA_TOLERANCE,
   resultRows,
+  type SystemMailKind,
   utcDay,
   WARN_BOUNCE_RATE,
   WARN_COMPLAINT_RATE,
@@ -23,7 +34,20 @@ import {
 } from "@millionsend/core";
 import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
-import { and, eq, gt, gte, like, lt, or, sql } from "drizzle-orm";
+import {
+  and,
+  eq,
+  gt,
+  gte,
+  inArray,
+  isNotNull,
+  like,
+  lt,
+  ne,
+  notInArray,
+  or,
+  sql,
+} from "drizzle-orm";
 import {
   deliverabilityPausedMail,
   deliverabilityWarningMail,
@@ -35,7 +59,7 @@ import {
   webhookBacklogMail,
   webhookFailingMail,
 } from "../notifications/templates.js";
-import type { SystemMailer } from "../system-mail.js";
+import { mailOwners as mailTeamOwners, type SystemMailer } from "../system-mail.js";
 import { COUNTED_SETTLED_SQL, WEBHOOK_AUTO_DISABLE_AFTER } from "./deliver-webhook.js";
 
 export interface NotifyDeps {
@@ -48,6 +72,11 @@ export interface NotifyDeps {
 
 /** Share of the daily quota at which owners hear about it. */
 export const QUOTA_WARNING_RATIO = 0.8;
+/** Days ahead of a scheduled cancellation at which owners are reminded. */
+export const CANCEL_REMINDER_DAYS = 3;
+/** Audit actions owners hear about; rows older than a day are never read. */
+const AUDIT_MAILED = ["api_key.created", "webhook.secret_rotated", "member.joined"] as const;
+type AuditMailed = (typeof AUDIT_MAILED)[number];
 /**
  * A deliverability episode ends only once the 7-day rates are this far under
  * the warning lines: a sender hovering at the line would otherwise be
@@ -156,7 +185,7 @@ export async function sweepNotifications(db: Db, deps: NotifyDeps): Promise<{ se
   // never stops the sweep for the others.
   const attempt = async (
     teamId: string,
-    type: NotificationType,
+    type: SystemMailKind,
     what: string,
     fn: () => Promise<void>,
   ) => {
@@ -166,14 +195,26 @@ export async function sweepNotifications(db: Db, deps: NotifyDeps): Promise<{ se
       console.error(`notifications.sweep: ${type} for team ${teamId} failed (${what})`, err);
     }
   };
-  const mailOwners = async (teamId: string, type: NotificationType, mail: MailContent) => {
-    for (const owner of await listTeamOwners(db, teamId)) {
-      await attempt(teamId, type, `mail to ${owner.email}`, () =>
-        deps.mailer.send(owner.email, { ...mail, kind: type }),
-      );
-    }
+  const mailOwners = async (
+    teamId: string,
+    kind: SystemMailKind,
+    mail: MailContent | ((locale: MailLocale) => MailContent),
+    opts?: { except?: string; also?: { email: string; locale: MailLocale } },
+  ) => {
+    await mailTeamOwners(
+      db,
+      deps.mailer,
+      teamId,
+      kind,
+      typeof mail === "function" ? mail : () => mail,
+      opts,
+    );
     sent += 1;
   };
+  const account =
+    (kind: AccountMailKind, path: string, values: (locale: MailLocale) => Record<string, string>) =>
+    (locale: MailLocale) =>
+      buildAccountMail({ kind, locale, url: `${base}${path}`, values: values(locale) });
   const notify = async (
     teamId: string,
     type: Exclude<NotificationType, `webhook.${string}`>,
@@ -374,6 +415,284 @@ export async function sweepNotifications(db: Db, deps: NotifyDeps): Promise<{ se
         ? deliverabilityPausedMail(input)
         : deliverabilityWarningMail(input),
     );
+  }
+
+  // Sender domains: verification gained or lost is an episode per domain,
+  // whichever surface moved it (dashboard, REST, the re-verify sweep). Only
+  // domains that verified at least once take part; a domain that never did
+  // has nothing to lose yet.
+  const domainRows = await db
+    .select({
+      id: schema.domains.id,
+      name: schema.domains.name,
+      teamId: schema.domains.teamId,
+      status: schema.domains.status,
+    })
+    .from(schema.domains)
+    .where(isNotNull(schema.domains.verifiedAt));
+  const domainClaims = await db
+    .select({ teamId: schema.teamNotifications.teamId, kind: schema.teamNotifications.kind })
+    .from(schema.teamNotifications)
+    .where(like(schema.teamNotifications.kind, "domain.%"));
+  const domainClaimed = new Set(domainClaims.map((c) => `${c.teamId}:${c.kind}`));
+  const liveDomains = new Set(domainRows.map((d) => d.id));
+  for (const c of domainClaims) {
+    if (!liveDomains.has(c.kind.slice(c.kind.indexOf(":") + 1))) {
+      await clearNotifications(db, { teamId: c.teamId, kind: c.kind });
+    }
+  }
+  for (const d of domainRows) {
+    const gained = `domain.verified:${d.id}`;
+    const lost = `domain.lost:${d.id}`;
+    const values = () => ({ domain: d.name });
+    if (d.status === "verified") {
+      if (domainClaimed.has(`${d.teamId}:${lost}`)) {
+        await clearNotifications(db, { teamId: d.teamId, kind: lost });
+      }
+      if (await claimNotification(db, { teamId: d.teamId, kind: gained, periodKey: "episode" })) {
+        await mailOwners(
+          d.teamId,
+          "domain.verified",
+          account("domain.verified", `/domains/${d.id}`, values),
+        );
+      }
+      continue;
+    }
+    if (domainClaimed.has(`${d.teamId}:${gained}`)) {
+      await clearNotifications(db, { teamId: d.teamId, kind: gained });
+    }
+    if (await claimNotification(db, { teamId: d.teamId, kind: lost, periodKey: "episode" })) {
+      // SES marks a domain failed for good when its identity is gone or it
+      // gave up on the records; anything else is a record that can come back.
+      const kind = d.status === "failed" ? "domain.lost.identity" : "domain.lost";
+      const path = d.status === "failed" ? "/domains" : `/domains/${d.id}`;
+      await mailOwners(d.teamId, kind, account(kind, path, values));
+    }
+  }
+
+  // Security receipts off the audit trail, one per row. A row for a team
+  // that is gone is skipped by the join; claims for rows that left the
+  // window are dropped, since those rows are never read again.
+  const auditSince = new Date(now.getTime() - DAY_MS);
+  const auditActions = [...AUDIT_MAILED];
+  await db.delete(schema.teamNotifications).where(
+    and(
+      inArray(schema.teamNotifications.kind, auditActions),
+      notInArray(
+        schema.teamNotifications.periodKey,
+        db
+          .select({ id: sql<string>`${schema.auditLog.id}::text` })
+          .from(schema.auditLog)
+          .where(
+            and(
+              inArray(schema.auditLog.action, auditActions),
+              gt(schema.auditLog.createdAt, auditSince),
+            ),
+          ),
+      ),
+    ),
+  );
+  const auditRows = await db
+    .select({
+      id: schema.auditLog.id,
+      teamId: schema.teams.id,
+      team: schema.teams.name,
+      actorId: schema.auditLog.actorId,
+      action: schema.auditLog.action,
+      target: schema.auditLog.target,
+      data: schema.auditLog.data,
+    })
+    .from(schema.auditLog)
+    .innerJoin(schema.teams, eq(schema.teams.id, schema.auditLog.teamId))
+    .where(
+      and(inArray(schema.auditLog.action, auditActions), gt(schema.auditLog.createdAt, auditSince)),
+    )
+    .orderBy(schema.auditLog.createdAt);
+  const from = accountEmailFrom();
+  for (const row of auditRows) {
+    const action = row.action as AuditMailed;
+    if (!(await claimNotification(db, { teamId: row.teamId, kind: action, periodKey: row.id }))) {
+      continue;
+    }
+    await attempt(row.teamId, action, `audit row ${row.id}`, async () => {
+      const targetId = row.target?.slice(row.target.indexOf(":") + 1) ?? "";
+      const data = row.data ?? {};
+      const actor = parseAuditActor(row.actorId);
+      const actorUser =
+        actor.kind === "user"
+          ? (
+              await db
+                .select({ name: schema.user.name, email: schema.user.email })
+                .from(schema.user)
+                .where(eq(schema.user.id, actor.id))
+            )[0]
+          : undefined;
+      const actorLabel = (locale: MailLocale) =>
+        actorUser
+          ? actorUser.name || actorUser.email
+          : accountMailPhrase({
+              locale,
+              kind: "api_key.created",
+              key:
+                actor.kind === "api_key"
+                  ? "apiKeyActor"
+                  : actor.kind === "oauth"
+                    ? "mcpActor"
+                    : "systemActor",
+            });
+      if (action === "api_key.created") {
+        const [key] = await db
+          .select({
+            name: schema.apiKeys.name,
+            prefix: schema.apiKeys.tokenPrefix,
+            last4: schema.apiKeys.last4,
+            permission: schema.apiKeys.permission,
+            domainId: schema.apiKeys.domainId,
+          })
+          .from(schema.apiKeys)
+          .where(eq(schema.apiKeys.id, targetId));
+        if (!key) throw new Error("api key row missing");
+        const [domain] = key.domainId
+          ? await db
+              .select({ name: schema.domains.name })
+              .from(schema.domains)
+              .where(eq(schema.domains.id, key.domainId))
+          : [];
+        await mailOwners(
+          row.teamId,
+          action,
+          account(action, "/api-keys", (locale) => ({
+            team: row.team,
+            actor: actorLabel(locale),
+            name: typeof data.name === "string" ? data.name : key.name,
+            prefix: key.prefix,
+            last4: key.last4,
+            permission: accountMailPhrase({ locale, kind: action, key: key.permission }),
+            scope: domain
+              ? accountMailPhrase({
+                  locale,
+                  kind: action,
+                  key: "scope",
+                  values: { domain: domain.name },
+                })
+              : "",
+          })),
+          actorUser
+            ? {
+                also: {
+                  email: actorUser.email,
+                  locale: await accountLocale(db, from, actorUser.email),
+                },
+              }
+            : undefined,
+        );
+      } else if (action === "webhook.secret_rotated") {
+        const url = typeof data.url === "string" ? data.url : "";
+        const expires =
+          typeof data.previousSecretExpiresAt === "string"
+            ? new Date(data.previousSecretExpiresAt)
+            : null;
+        let host = url;
+        try {
+          host = new URL(url).host;
+        } catch {}
+        await mailOwners(
+          row.teamId,
+          action,
+          account(action, `/webhooks/${targetId}`, (locale) => ({
+            team: row.team,
+            actor: actorLabel(locale),
+            url,
+            host,
+            until: expires
+              ? formatMailDateTime(locale, expires)
+              : accountMailPhrase({ locale, kind: action, key: "immediately" }),
+          })),
+        );
+      } else {
+        const [joiner] = await db
+          .select({ name: schema.user.name, email: schema.user.email })
+          .from(schema.user)
+          .where(eq(schema.user.id, targetId));
+        if (!joiner) throw new Error("joined user missing");
+        const role = typeof data.role === "string" ? data.role : "member";
+        await mailOwners(
+          row.teamId,
+          action,
+          account(action, "/settings", (locale) => ({
+            team: row.team,
+            name: joiner.name || joiner.email,
+            email: joiner.email,
+            role: accountMailPhrase({ locale, kind: action, key: role }),
+          })),
+          { except: joiner.email },
+        );
+      }
+    });
+  }
+
+  if (deps.isCloud) {
+    // Paid plans: a cancellation a few days out, and a period that lapsed
+    // past its grace without Stripe saying so (the day effectivePlan starts
+    // answering free). The downgrade claim is keyed by the period end, the
+    // key the webhook route uses, so whichever notices first is the one.
+    const freeCap = (locale: MailLocale) => (PLAN_DAILY_LIMIT.free ?? 0).toLocaleString(locale);
+    const paid = await db
+      .select({
+        id: schema.teams.id,
+        name: schema.teams.name,
+        plan: schema.teams.plan,
+        currentPeriodEnd: schema.teams.currentPeriodEnd,
+        cancelAt: schema.teams.cancelAt,
+      })
+      .from(schema.teams)
+      .where(ne(schema.teams.plan, "free"));
+    for (const t of paid) {
+      const endsAt = t.cancelAt;
+      if (
+        endsAt &&
+        endsAt.getTime() > now.getTime() &&
+        endsAt.getTime() <= now.getTime() + CANCEL_REMINDER_DAYS * DAY_MS &&
+        (await claimNotification(db, {
+          teamId: t.id,
+          kind: "billing.cancel_reminder",
+          periodKey: endsAt.toISOString(),
+        }))
+      ) {
+        await mailOwners(
+          t.id,
+          "billing.cancel_reminder",
+          account("billing.cancel_reminder", "/settings/billing", (locale) => ({
+            team: t.name,
+            plan: PLAN_NAME[t.plan],
+            date: formatMailDate(locale, endsAt),
+            cap: planCapPhrase(locale, t.plan),
+            freeCap: freeCap(locale),
+          })),
+        );
+      }
+      const periodEnd = t.currentPeriodEnd;
+      if (
+        periodEnd &&
+        effectivePlan(t.plan, periodEnd, now) === "free" &&
+        (await claimNotification(db, {
+          teamId: t.id,
+          kind: "billing.downgraded",
+          periodKey: periodEnd.toISOString(),
+        }))
+      ) {
+        await mailOwners(
+          t.id,
+          "billing.downgraded",
+          account("billing.downgraded", "/settings/billing", (locale) => ({
+            team: t.name,
+            plan: PLAN_NAME[t.plan],
+            date: formatMailDate(locale, periodEnd),
+            freeCap: freeCap(locale),
+          })),
+        );
+      }
+    }
   }
 
   return { sent };

--- a/apps/worker/src/handlers/send-broadcast.ts
+++ b/apps/worker/src/handlers/send-broadcast.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from "node:crypto";
 import {
+  type AccountMailKind,
   applyMergeFields,
   broadcastSendSpacingMs,
+  buildAccountMail,
   buildUnsubscribeHeaders,
+  claimNotification,
   encryptEmailBody,
   fetchDeliverabilityHealth,
   fetchEffectivePlan,
@@ -10,7 +13,9 @@ import {
   injectPreheader,
   isSubscribedToTopic,
   type Keyring,
+  type MailLocale,
   makeUnsubscribeToken,
+  nextUtcDayStart,
   PLAN_DAILY_LIMIT,
   parseSingleSender,
   regionPause,
@@ -22,6 +27,7 @@ import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
 import type { EmailSendRequest, EnqueueEmailSends } from "@millionsend/queue";
 import { and, asc, eq, gt, inArray, type SQL, sql } from "drizzle-orm";
+import { mailOwners, type SystemMailer } from "../system-mail.js";
 
 /**
  * Fans a broadcast out into individual email rows and email.send jobs — the
@@ -52,6 +58,42 @@ export interface BroadcastDeps {
    */
   signal?: AbortSignal | undefined;
   batchSize?: number | undefined;
+  /** Owners hear when the broadcast went out or is held; absent = silent (tests). */
+  mailer?: SystemMailer | undefined;
+  /** Dashboard origin for the links in those mails. */
+  appBaseUrl?: string | undefined;
+}
+
+/**
+ * One report to the owners about a broadcast; never throws, the fan-out's
+ * outcome stands whatever the mail does.
+ */
+async function report(
+  db: Db,
+  deps: BroadcastDeps,
+  broadcast: { id: string; teamId: string },
+  kind: AccountMailKind,
+  path: string,
+  values: (locale: MailLocale, team: string) => Record<string, string>,
+): Promise<void> {
+  if (!deps.mailer) return;
+  try {
+    const [team] = await db
+      .select({ name: schema.teams.name })
+      .from(schema.teams)
+      .where(eq(schema.teams.id, broadcast.teamId));
+    if (!team) return;
+    await mailOwners(db, deps.mailer, broadcast.teamId, kind, (locale) =>
+      buildAccountMail({
+        kind,
+        locale,
+        url: `${deps.appBaseUrl ?? ""}${path}`,
+        values: values(locale, team.name),
+      }),
+    );
+  } catch (err) {
+    console.error(`broadcast ${broadcast.id}: ${kind} mail skipped`, err);
+  }
 }
 
 export type BroadcastOutcome = "sent" | "skipped" | "deferred";
@@ -122,6 +164,28 @@ export async function sendBroadcast(
   // Platform breaker: a broadcast scheduled before its region was held waits
   // it out like a not-yet-due one; the reconcile sweep keeps it alive.
   if (await regionPause(db, domain.region)) {
+    // Said once per broadcast, however many 15-minute waits the hold lasts.
+    if (
+      deps.mailer &&
+      (await claimNotification(db, {
+        teamId: broadcast.teamId,
+        kind: `broadcast.held:${broadcast.id}`,
+        periodKey: "region",
+      }))
+    ) {
+      await report(
+        db,
+        deps,
+        broadcast,
+        "broadcast.held",
+        `/broadcasts/${broadcast.id}`,
+        (_, team) => ({
+          name: broadcast.name ?? broadcast.subject,
+          region: domain.region,
+          team,
+        }),
+      );
+    }
     await deps.reschedule?.(broadcast.id, new Date(Date.now() + REGION_HOLD_RETRY_MS));
     return "deferred";
   }
@@ -374,7 +438,7 @@ export async function sendBroadcast(
     }
   }
 
-  await db
+  const [done] = await db
     .update(schema.broadcasts)
     .set({
       status: "sent",
@@ -384,6 +448,62 @@ export async function sendBroadcast(
       // join the emails table to size a broadcast.
       recipientCount: sql`(select count(*)::int from ${schema.emails} where ${schema.emails.broadcastId} = ${broadcast.id})`,
     })
-    .where(and(eq(schema.broadcasts.id, broadcast.id), eq(schema.broadcasts.status, "sending")));
+    .where(and(eq(schema.broadcasts.id, broadcast.id), eq(schema.broadcasts.status, "sending")))
+    .returning({ recipientCount: schema.broadcasts.recipientCount });
+  // The report follows the flip and is claimed per broadcast, so a walk that
+  // resumed after a crash or a reconcile re-kick reports once.
+  if (
+    done &&
+    deps.mailer &&
+    (await claimNotification(db, {
+      teamId: broadcast.teamId,
+      kind: "broadcast.sent",
+      periodKey: broadcast.id,
+    }))
+  ) {
+    const count = done.recipientCount ?? 0;
+    const [{ parked } = { parked: 0 }] = await db
+      .select({ parked: sql<number>`count(*)::int` })
+      .from(schema.emails)
+      .where(
+        and(
+          eq(schema.emails.broadcastId, broadcast.id),
+          eq(schema.emails.latestStatus, "queued_quota"),
+        ),
+      );
+    const name = broadcast.name ?? broadcast.subject;
+    if (parked > 0) {
+      await report(
+        db,
+        deps,
+        broadcast,
+        "broadcast.held_quota",
+        "/settings/billing",
+        (locale, team) => ({
+          name,
+          team,
+          count: count.toLocaleString(locale),
+          parked: parked.toLocaleString(locale),
+          sent: (count - parked).toLocaleString(locale),
+          limit: (dailyLimit ?? 0).toLocaleString(locale),
+          resetsAt: nextUtcDayStart(Date.now()).toISOString().slice(11, 16),
+        }),
+      );
+    } else {
+      await report(
+        db,
+        deps,
+        broadcast,
+        "broadcast.sent",
+        `/broadcasts/${broadcast.id}`,
+        (locale, team) => ({
+          name,
+          subject: broadcast.subject,
+          team,
+          count: count.toLocaleString(locale),
+        }),
+      );
+    }
+  }
   return "sent";
 }

--- a/apps/worker/src/notifications/templates.ts
+++ b/apps/worker/src/notifications/templates.ts
@@ -1,37 +1,26 @@
-import { EMAIL_WORDMARK_URL, escapeHtml, QUOTA_TOLERANCE } from "@millionsend/core";
+import { accountMailCard, type MailContent, QUOTA_TOLERANCE } from "@millionsend/core";
 
-export interface MailContent {
-  subject: string;
-  html: string;
-  text: string;
-}
+export type { MailContent };
 
-const MUTED = 'style="font-size:13px;line-height:1.5;color:#52525b;margin:24px 0 0"';
-
-/** The one system-mail layout: wordmark, white card, paragraphs, one button. */
+/**
+ * Owner notices on the shared account-mail card: the notice names its button
+ * and one muted footnote, and the text version reads "Button: url".
+ */
 function layout(input: {
   subject: string;
   paragraphs: string[];
   button: { label: string; url: string };
   footnote: string;
 }): MailContent {
-  const url = escapeHtml(input.button.url);
-  const body = input.paragraphs
-    .map(
-      (p) =>
-        `<p style="font-size:14px;line-height:1.5;color:#18181b;margin:0 0 12px">${escapeHtml(p)}</p>`,
-    )
-    .join("\n    ");
-  const html = `<div style="background:#f4f4f5;padding:32px 16px;font-family:-apple-system,'Segoe UI',Roboto,sans-serif">
-  <div style="max-width:440px;margin:0 auto;background:#ffffff;border-radius:12px;padding:32px">
-    <img src="${EMAIL_WORDMARK_URL}" width="174" height="24" alt="MillionSend" style="display:block;height:24px;width:auto;margin:0 0 24px;border:0">
-    ${body}
-    <a href="${url}" style="display:inline-block;background:#18181b;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;border-radius:8px;padding:12px 20px;margin-top:12px">${escapeHtml(input.button.label)}</a>
-    <p ${MUTED}>${escapeHtml(input.footnote)}</p>
-  </div>
-</div>`;
-  const text = `${input.paragraphs.join("\n\n")}\n\n${input.button.label}: ${input.button.url}\n\n${input.footnote}\n`;
-  return { subject: input.subject, html, text };
+  return {
+    subject: input.subject,
+    ...accountMailCard({
+      paragraphs: input.paragraphs,
+      button: input.button.label,
+      url: input.button.url,
+      muted: [input.footnote],
+    }),
+  };
 }
 
 const percent = (rate: number) => `${(rate * 100).toFixed(2)}%`;

--- a/apps/worker/src/server.ts
+++ b/apps/worker/src/server.ts
@@ -51,7 +51,7 @@ import {
   stripExpiredEventPayloads,
 } from "./handlers/cron.js";
 import { drainWebhookEndpoint } from "./handlers/deliver-webhook.js";
-import { sweepNotifications } from "./handlers/notify.js";
+import { reportPlanMove, sweepNotifications } from "./handlers/notify.js";
 import { runPlatformBreaker } from "./handlers/platform-breaker.js";
 import { processSesEvent } from "./handlers/process-ses-event.js";
 import { sendBroadcast } from "./handlers/send-broadcast.js";
@@ -251,6 +251,9 @@ await queue.scheduleCrons({
     if (!stripe) return;
     const result = await reconcileBillingPlans(db, {
       reconcileTeam: (teamId) => reconcileTeamPlan({ db, stripe, log: console.warn }, teamId),
+      onPlanMoved: async (team, before, after) => {
+        await reportPlanMove(db, mailer, env.APP_BASE_URL ?? "", team, before, after);
+      },
     });
     console.log(`billing.reconcile: reconciled=${result.reconciled} failed=${result.failed}`);
   },

--- a/apps/worker/src/server.ts
+++ b/apps/worker/src/server.ts
@@ -391,6 +391,8 @@ await queue.work(
         enqueueEmailSends: enqueueSends,
         reschedule: (broadcastId, at) => enqueueBroadcast(broadcastId, at),
         signal: ctx.signal,
+        mailer,
+        appBaseUrl: env.APP_BASE_URL,
       },
       payload,
     );

--- a/apps/worker/src/system-mail.ts
+++ b/apps/worker/src/system-mail.ts
@@ -75,7 +75,7 @@ export async function mailOwners(
   build: (locale: MailLocale) => MailContent,
   opts: { except?: string; also?: { email: string; locale: MailLocale } } = {},
 ): Promise<number> {
-  const owners = await listTeamOwners(db, teamId, accountEmailFrom());
+  const owners = await listTeamOwners(db, teamId, accountEmailFrom(), kind);
   const recipients = owners.filter(
     (owner) => owner.email.toLowerCase() !== opts.except?.toLowerCase(),
   );

--- a/apps/worker/src/system-mail.ts
+++ b/apps/worker/src/system-mail.ts
@@ -1,6 +1,9 @@
-import { env, notificationsEmailFrom } from "@millionsend/config";
+import { accountEmailFrom, env, notificationsEmailFrom } from "@millionsend/config";
 import {
   type Keyring,
+  listTeamOwners,
+  type MailContent,
+  type MailLocale,
   type SystemMailKind,
   type SystemMailMessage,
   sendSystemMail,
@@ -56,4 +59,40 @@ export function createSystemMailer(deps: {
       await sendSystemMail(sendDeps, { from, to, ...message });
     },
   };
+}
+
+/**
+ * One notice to every owner of a team, each in their own language; a
+ * failing send is logged and the others still go out. `except` drops an
+ * owner who is the subject of the notice; `also` adds a recipient who is
+ * not an owner (the person who created a key). Returns how many went out.
+ */
+export async function mailOwners(
+  db: Db,
+  mailer: SystemMailer,
+  teamId: string,
+  kind: SystemMailKind,
+  build: (locale: MailLocale) => MailContent,
+  opts: { except?: string; also?: { email: string; locale: MailLocale } } = {},
+): Promise<number> {
+  const owners = await listTeamOwners(db, teamId, accountEmailFrom());
+  const recipients = owners.filter(
+    (owner) => owner.email.toLowerCase() !== opts.except?.toLowerCase(),
+  );
+  if (
+    opts.also &&
+    !recipients.some((r) => r.email.toLowerCase() === opts.also?.email.toLowerCase())
+  ) {
+    recipients.push({ email: opts.also.email, name: "", locale: opts.also.locale });
+  }
+  let sent = 0;
+  for (const recipient of recipients) {
+    try {
+      await mailer.send(recipient.email, { ...build(recipient.locale), kind });
+      sent += 1;
+    } catch (err) {
+      console.error(`system mail: ${kind} to ${recipient.email} failed`, err);
+    }
+  }
+  return sent;
 }

--- a/apps/worker/test/cron.test.ts
+++ b/apps/worker/test/cron.test.ts
@@ -644,6 +644,43 @@ it("billing reconcile visits only teams with a Stripe customer and isolates fail
   expect(visited.sort()).toEqual([withStripe, failing].sort());
 });
 
+it("billing reconcile reports a plan it moved, with the row before and after", async () => {
+  const teamId = await createTeam(db, "lapsed-team");
+  const periodEnd = new Date("2026-08-30T00:00:00Z");
+  await db
+    .update(schema.teams)
+    .set({ stripeCustomerId: "cus_9", plan: "pro", currentPeriodEnd: periodEnd })
+    .where(eq(schema.teams.id, teamId));
+  const moves: { team: string; before: string; after: string }[] = [];
+  const deps = {
+    // Stands in for Stripe answering that the subscription is gone.
+    reconcileTeam: async (id: string) => {
+      await db
+        .update(schema.teams)
+        .set({ plan: "free", currentPeriodEnd: null })
+        .where(eq(schema.teams.id, id));
+    },
+    onPlanMoved: async (
+      team: { id: string; name: string },
+      before: { plan: string; currentPeriodEnd: Date | null },
+      after: { plan: string },
+    ) => {
+      moves.push({
+        team: team.name,
+        before: `${before.plan}:${before.currentPeriodEnd?.toISOString()}`,
+        after: after.plan,
+      });
+    },
+  };
+  await reconcileBillingPlans(db, deps);
+  expect(moves).toEqual([
+    { team: "lapsed-team", before: `pro:${periodEnd.toISOString()}`, after: "free" },
+  ]);
+  // Nothing moved the second time: nothing to report.
+  await reconcileBillingPlans(db, deps);
+  expect(moves).toHaveLength(1);
+});
+
 it("holds every parked email while SES's own 24-hour quota is full", async () => {
   await insertParked(new Date("2026-08-13T01:00:00Z"));
   const enqueued: string[] = [];

--- a/apps/worker/test/notify.test.ts
+++ b/apps/worker/test/notify.test.ts
@@ -653,3 +653,25 @@ it("an owner whose account contact is pt-BR reads the notice in pt-BR", async ()
   await sweepNotifications(db, deps(false));
   expect(sends.map((s) => s.subject)).toEqual(["mail.acme.dev está verificado"]);
 });
+
+it("an owner who turned a notice off is skipped for it, and still gets a security receipt", async () => {
+  await db
+    .update(schema.user)
+    .set({ mailOptOuts: ["domain.verified"] })
+    .where(eq(schema.user.id, "owner"));
+  await domain();
+  await sweepNotifications(db, deps(false));
+  expect(sends).toEqual([]);
+  const [key] = await db
+    .insert(schema.apiKeys)
+    .values({ teamId, name: "ci", tokenPrefix: "ms_live_abc", keyHash: "h1", last4: "wxyz" })
+    .returning({ id: schema.apiKeys.id });
+  await audit("api_key.created", {
+    target: `api_key:${key?.id}`,
+    data: { name: "ci", permission: "full_access", domainId: null },
+  });
+  await sweepNotifications(db, deps(false));
+  expect(sends.map((s) => [s.to, s.subject])).toEqual([
+    ["owner@example.com", "New API key in notify-team: ci"],
+  ]);
+});

--- a/apps/worker/test/notify.test.ts
+++ b/apps/worker/test/notify.test.ts
@@ -2,6 +2,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import {
   EnvKeyring,
   encryptWebhookSecret,
+  formatMailDate,
   generateWebhookSecret,
   type QueuedWebhookDelivery,
   utcDay,
@@ -508,6 +509,21 @@ it("a new API key is reported once to the owners and to the person who created i
   await sweepNotifications(db, deps(false));
   expect(sends).toHaveLength(2);
 
+  // Removed from the team since: the owners still hear it, the ex-member does not.
+  await db.delete(schema.teamMembers).where(eq(schema.teamMembers.userId, "adm"));
+  const [later] = await db
+    .insert(schema.apiKeys)
+    .values({ teamId, name: "later", tokenPrefix: "ms_live_ghi", keyHash: "h3", last4: "5678" })
+    .returning({ id: schema.apiKeys.id });
+  await audit("api_key.created", {
+    actor: "user:adm",
+    target: `api_key:${later?.id}`,
+    data: { name: "later", permission: "full_access", domainId: null },
+  });
+  await sweepNotifications(db, deps(false));
+  expect(sends.slice(2).map((s) => s.to)).toEqual(["owner@example.com"]);
+  expect(sends[2]?.text).toContain('Ada created the API key "later"');
+
   // A key minted by another key names no person; the owner is the only reader.
   const [minted] = await db
     .insert(schema.apiKeys)
@@ -519,8 +535,8 @@ it("a new API key is reported once to the owners and to the person who created i
     data: { name: "child", permission: "full_access", domainId: null },
   });
   await sweepNotifications(db, deps(false));
-  expect(sends).toHaveLength(3);
-  expect(sends[2]?.text).toContain(
+  expect(sends).toHaveLength(4);
+  expect(sends[3]?.text).toContain(
     'an API key created the API key "child" (ms_live_def…1234, full access) in',
   );
 });
@@ -547,7 +563,8 @@ it("a rotated webhook secret names the endpoint and the old secret's deadline", 
     data: { url: "https://receiver.example.com/hook", previousSecretExpiresAt: null },
   });
   await sweepNotifications(db, deps(false));
-  expect(sends[1]?.text).toContain("until now — it stopped verifying immediately;");
+  expect(sends[1]?.text).toContain("The previous secret stopped verifying at once;");
+  expect(sends[1]?.text).not.toContain("keeps verifying");
 });
 
 it("a member who joined is reported to the other owners, never to themselves", async () => {
@@ -591,7 +608,9 @@ it("a scheduled cancellation is recalled three days out, once, on the cloud only
   expect(await sweepNotifications(db, deps(false))).toEqual({ sent: 0 });
   expect(await sweepNotifications(db, deps())).toEqual({ sent: 1 });
   await sweepNotifications(db, deps());
-  expect(sends.map((s) => s.subject)).toEqual(["notify-team's Pro plan ends in 3 days"]);
+  expect(sends.map((s) => s.subject)).toEqual([
+    `Reminder: notify-team's Pro plan ends on ${formatMailDate("en", endsAt)}`,
+  ]);
   expect(sends[0]?.text).toContain("to keep sending up to 3,000 emails a day");
 
   // Too far out to count down yet; a fresh date is its own reminder.

--- a/apps/worker/test/notify.test.ts
+++ b/apps/worker/test/notify.test.ts
@@ -376,3 +376,261 @@ it("rows exhausted without running out of retries do not read as a failing endpo
   await delivery("exhausted", { count: 10 });
   expect(await sweepNotifications(db, deps(false))).toEqual({ sent: 1 });
 });
+
+const DAY = 86_400_000;
+
+async function domain(
+  status: "verified" | "pending" | "temporary_failure" | "failed" = "verified",
+) {
+  const [row] = await db
+    .insert(schema.domains)
+    .values({ teamId, name: "mail.acme.dev", region: "us-east-1", status, verifiedAt: new Date() })
+    .returning({ id: schema.domains.id });
+  if (!row) throw new Error("domain insert failed");
+  return row.id;
+}
+
+async function setDomain(id: string, status: "verified" | "temporary_failure" | "failed") {
+  await db.update(schema.domains).set({ status }).where(eq(schema.domains.id, id));
+}
+
+async function claims(prefix: string) {
+  return (
+    await db
+      .select({ kind: schema.teamNotifications.kind })
+      .from(schema.teamNotifications)
+      .where(like(schema.teamNotifications.kind, `${prefix}%`))
+  ).map((c) => c.kind);
+}
+
+it("a domain is announced once when it verifies; losing a record says so once and re-arms the announcement", async () => {
+  const id = await domain();
+  expect(await sweepNotifications(db, deps(false))).toEqual({ sent: 1 });
+  expect(sends.map((s) => s.subject)).toEqual(["mail.acme.dev is verified"]);
+  expect(sends[0]?.text).toContain(`https://app.example.test/domains/${id}`);
+  await sweepNotifications(db, deps(false));
+  expect(sends).toHaveLength(1);
+
+  await setDomain(id, "temporary_failure");
+  await sweepNotifications(db, deps(false));
+  await sweepNotifications(db, deps(false));
+  expect(sends.map((s) => s.subject)).toEqual([
+    "mail.acme.dev is verified",
+    "mail.acme.dev lost its verification",
+  ]);
+  expect(sends[1]?.text).toContain("DKIM or MAIL FROM");
+  expect(await claims("domain.")).toEqual([`domain.lost:${id}`]);
+
+  await setDomain(id, "verified");
+  await sweepNotifications(db, deps(false));
+  expect(sends).toHaveLength(3);
+  expect(await claims("domain.")).toEqual([`domain.verified:${id}`]);
+
+  // SES giving up is terminal: the mail says to add the domain again.
+  await setDomain(id, "failed");
+  await sweepNotifications(db, deps(false));
+  expect(sends[3]?.text).toContain("given up on mail.acme.dev");
+  expect(sends[3]?.text).toContain("https://app.example.test/domains\n");
+
+  await db.delete(schema.domains).where(eq(schema.domains.id, id));
+  await sweepNotifications(db, deps(false));
+  expect(await claims("domain.")).toEqual([]);
+});
+
+it("a domain that verified before the sweep existed, or never did, says nothing", async () => {
+  const seeded = await domain();
+  await db
+    .insert(schema.teamNotifications)
+    .values({ teamId, kind: `domain.verified:${seeded}`, periodKey: "episode" });
+  await db
+    .insert(schema.domains)
+    .values({ teamId, name: "new.acme.dev", region: "us-east-1", status: "pending" });
+  expect(await sweepNotifications(db, deps(false))).toEqual({ sent: 0 });
+  expect(sends).toEqual([]);
+});
+
+async function audit(
+  action: "api_key.created" | "webhook.secret_rotated" | "member.joined",
+  opts: {
+    actor?: string | null;
+    target?: string;
+    data?: Record<string, unknown>;
+    team?: string;
+    createdAt?: Date;
+  } = {},
+) {
+  const [row] = await db
+    .insert(schema.auditLog)
+    .values({
+      teamId: opts.team ?? teamId,
+      actorId: opts.actor === undefined ? "user:owner" : opts.actor,
+      action,
+      target: opts.target ?? null,
+      data: opts.data ?? null,
+      ...(opts.createdAt ? { createdAt: opts.createdAt } : {}),
+    })
+    .returning({ id: schema.auditLog.id });
+  if (!row) throw new Error("audit insert failed");
+  return row.id;
+}
+
+it("a new API key is reported once to the owners and to the person who created it", async () => {
+  await db.insert(schema.user).values({ id: "adm", name: "Ada", email: "ada@example.com" });
+  await db.insert(schema.teamMembers).values({ teamId, userId: "adm", role: "admin" });
+  const [scoped] = await db
+    .insert(schema.domains)
+    .values({ teamId, name: "mail.acme.dev", region: "us-east-1", status: "verified" })
+    .returning({ id: schema.domains.id });
+  const [key] = await db
+    .insert(schema.apiKeys)
+    .values({
+      teamId,
+      name: "ci",
+      tokenPrefix: "ms_live_abc",
+      keyHash: "h1",
+      last4: "wxyz",
+      permission: "sending_access",
+      domainId: scoped?.id,
+    })
+    .returning({ id: schema.apiKeys.id });
+  await audit("api_key.created", {
+    actor: "user:adm",
+    target: `api_key:${key?.id}`,
+    data: { name: "ci", permission: "sending_access", domainId: scoped?.id },
+  });
+  expect(await sweepNotifications(db, deps(false))).toEqual({ sent: 1 });
+  expect(sends.map((s) => s.to).sort()).toEqual(["ada@example.com", "owner@example.com"]);
+  expect(sends[0]?.subject).toBe("New API key in notify-team: ci");
+  expect(sends[0]?.text).toContain(
+    'Ada created the API key "ci" (ms_live_abc…wxyz, sending access, limited to mail.acme.dev) in notify-team.',
+  );
+  expect(sends[0]?.text).toContain("https://app.example.test/api-keys");
+  await sweepNotifications(db, deps(false));
+  expect(sends).toHaveLength(2);
+
+  // A key minted by another key names no person; the owner is the only reader.
+  const [minted] = await db
+    .insert(schema.apiKeys)
+    .values({ teamId, name: "child", tokenPrefix: "ms_live_def", keyHash: "h2", last4: "1234" })
+    .returning({ id: schema.apiKeys.id });
+  await audit("api_key.created", {
+    actor: `api_key:${key?.id}`,
+    target: `api_key:${minted?.id}`,
+    data: { name: "child", permission: "full_access", domainId: null },
+  });
+  await sweepNotifications(db, deps(false));
+  expect(sends).toHaveLength(3);
+  expect(sends[2]?.text).toContain(
+    'an API key created the API key "child" (ms_live_def…1234, full access) in',
+  );
+});
+
+it("a rotated webhook secret names the endpoint and the old secret's deadline", async () => {
+  const endpointId = await endpoint();
+  await audit("webhook.secret_rotated", {
+    target: `webhook:${endpointId}`,
+    data: {
+      url: "https://receiver.example.com/hook",
+      previousSecretExpiresAt: "2026-09-10T15:00:00.000Z",
+    },
+  });
+  await sweepNotifications(db, deps(false));
+  expect(sends.map((s) => s.subject)).toEqual(["Webhook secret rotated for receiver.example.com"]);
+  expect(sends[0]?.text).toContain(
+    "Owner rotated the signing secret of https://receiver.example.com/hook in notify-team.",
+  );
+  expect(sends[0]?.text).toContain("until September 10, 2026 at 3:00 PM UTC;");
+  expect(sends[0]?.text).toContain(`https://app.example.test/webhooks/${endpointId}`);
+
+  await audit("webhook.secret_rotated", {
+    target: `webhook:${endpointId}`,
+    data: { url: "https://receiver.example.com/hook", previousSecretExpiresAt: null },
+  });
+  await sweepNotifications(db, deps(false));
+  expect(sends[1]?.text).toContain("until now — it stopped verifying immediately;");
+});
+
+it("a member who joined is reported to the other owners, never to themselves", async () => {
+  await db.insert(schema.user).values({ id: "j", name: "Jo", email: "jo@example.com" });
+  await db.insert(schema.teamMembers).values({ teamId, userId: "j", role: "owner" });
+  await audit("member.joined", { actor: "user:j", target: "user:j", data: { role: "owner" } });
+  await sweepNotifications(db, deps(false));
+  expect(sends.map((s) => s.to)).toEqual(["owner@example.com"]);
+  expect(sends[0]?.subject).toBe("Jo joined notify-team");
+  expect(sends[0]?.text).toContain(
+    "Jo (jo@example.com) accepted the invitation and is now an owner of notify-team.",
+  );
+});
+
+it("audit rows of a deleted team or older than a day are left alone, and their claims go", async () => {
+  await audit("member.joined", {
+    team: randomUUID(),
+    target: "user:owner",
+    data: { role: "member" },
+  });
+  await audit("member.joined", {
+    target: "user:owner",
+    data: { role: "member" },
+    createdAt: new Date(Date.now() - 2 * DAY),
+  });
+  await db
+    .insert(schema.teamNotifications)
+    .values({ teamId, kind: "member.joined", periodKey: randomUUID() });
+  expect(await sweepNotifications(db, deps(false))).toEqual({ sent: 0 });
+  expect(sends).toEqual([]);
+  expect(await claims("member.")).toEqual([]);
+});
+
+async function setPlan(values: Partial<typeof schema.teams.$inferInsert>) {
+  await db.update(schema.teams).set(values).where(eq(schema.teams.id, teamId));
+}
+
+it("a scheduled cancellation is recalled three days out, once, on the cloud only", async () => {
+  const endsAt = new Date(Date.now() + 2 * DAY);
+  await setPlan({ plan: "pro", cancelAt: endsAt });
+  expect(await sweepNotifications(db, deps(false))).toEqual({ sent: 0 });
+  expect(await sweepNotifications(db, deps())).toEqual({ sent: 1 });
+  await sweepNotifications(db, deps());
+  expect(sends.map((s) => s.subject)).toEqual(["notify-team's Pro plan ends in 3 days"]);
+  expect(sends[0]?.text).toContain("to keep sending up to 3,000 emails a day");
+
+  // Too far out to count down yet; a fresh date is its own reminder.
+  await setPlan({ cancelAt: new Date(Date.now() + 10 * DAY) });
+  await sweepNotifications(db, deps());
+  expect(sends).toHaveLength(1);
+});
+
+it("a paid period that lapsed past its grace reads as the downgrade, keyed like the webhook's", async () => {
+  const periodEnd = new Date(Date.now() - 8 * DAY);
+  await setPlan({ plan: "scale", currentPeriodEnd: periodEnd });
+  expect(await sweepNotifications(db, deps(false))).toEqual({ sent: 0 });
+  expect(await sweepNotifications(db, deps())).toEqual({ sent: 1 });
+  await sweepNotifications(db, deps());
+  expect(sends.map((s) => s.subject)).toEqual(["notify-team is now on Free"]);
+  expect(sends[0]?.text).toContain("The Scale plan ended on");
+  expect(
+    await db
+      .select({ key: schema.teamNotifications.periodKey })
+      .from(schema.teamNotifications)
+      .where(eq(schema.teamNotifications.kind, "billing.downgraded")),
+  ).toEqual([{ key: periodEnd.toISOString() }]);
+
+  // Still inside the grace window: nothing to say yet.
+  await setPlan({ currentPeriodEnd: new Date(Date.now() - 2 * DAY) });
+  await sweepNotifications(db, deps());
+  expect(sends).toHaveLength(1);
+});
+
+it("an owner whose account contact is pt-BR reads the notice in pt-BR", async () => {
+  vi.stubEnv("AUTH_EMAIL_FROM", "MillionSend <account@mail.example.com>");
+  const home = await createTeam(db, "home");
+  await db
+    .insert(schema.domains)
+    .values({ teamId: home, name: "mail.example.com", region: "us-east-1", status: "verified" });
+  await db
+    .insert(schema.contacts)
+    .values({ teamId: home, email: "owner@example.com", properties: { locale: "pt-BR" } });
+  await domain();
+  await sweepNotifications(db, deps(false));
+  expect(sends.map((s) => s.subject)).toEqual(["mail.acme.dev está verificado"]);
+});

--- a/apps/worker/test/send-broadcast.test.ts
+++ b/apps/worker/test/send-broadcast.test.ts
@@ -39,6 +39,12 @@ async function seedTeam(
   contacts: (Partial<typeof schema.contacts.$inferInsert> & { email: string })[],
 ): Promise<{ teamId: string; ids: Record<string, string> }> {
   const tId = await createTeam(db, label);
+  await db
+    .insert(schema.user)
+    .values({ id: `${label}-owner`, name: "", email: `${label}-owner@example.com` });
+  await db
+    .insert(schema.teamMembers)
+    .values({ teamId: tId, userId: `${label}-owner`, role: "owner" });
   await db.insert(schema.domains).values({
     teamId: tId,
     name: `${label}.dev`,
@@ -67,6 +73,17 @@ beforeAll(async () => {
   ]));
 });
 afterAll(() => close());
+
+/** Captures the owners' reports; every other test runs without a mailer and mails nothing. */
+function captureMailer() {
+  const sends: { to: string; kind: string; subject: string; text: string }[] = [];
+  const mailer: NonNullable<BroadcastDeps["mailer"]> = {
+    send: async (to, m) => {
+      sends.push({ to, kind: m.kind, subject: m.subject, text: m.text });
+    },
+  };
+  return { sends, mailer, appBaseUrl: BASE_URL };
+}
 
 function makeDeps(overrides: Partial<BroadcastDeps> = {}): {
   deps: BroadcastDeps;
@@ -125,9 +142,16 @@ const emailsOf = (broadcastId: string) =>
 
 it("a broadcast with no segment or topic fans out to ALL subscribed team contacts, personalizes, and marks sent", async () => {
   const broadcastId = await insertBroadcast();
-  const { deps, enqueued } = makeDeps();
+  const mail = captureMailer();
+  const { deps, enqueued } = makeDeps(mail);
 
   expect(await sendBroadcast(db, deps, { broadcastId })).toBe("sent");
+  // The owners' report: what went out, to how many, with the link.
+  expect(mail.sends.map((s) => [s.to, s.kind, s.subject])).toEqual([
+    ["acme-owner@example.com", "broadcast.sent", '"launch" went out to 2 recipients'],
+  ]);
+  expect(mail.sends[0]?.text).toContain('"launch" was handed to 2 contacts of acme;');
+  expect(mail.sends[0]?.text).toContain(`${BASE_URL}/broadcasts/${broadcastId}`);
 
   const rows = await emailsOf(broadcastId);
   expect(rows.map((r) => r.to[0]).sort()).toEqual(["a@example.com", "b@example.com"]);
@@ -222,9 +246,10 @@ it("suppressed recipients are skipped like unsubscribed ones", async () => {
   await db.delete(schema.contacts).where(eq(schema.contacts.id, extra.id));
 });
 
-it("re-running a fan-out never double-sends: no duplicate rows or jobs", async () => {
+it("re-running a fan-out never double-sends: no duplicate rows, jobs or reports", async () => {
   const broadcastId = await insertBroadcast();
-  const first = makeDeps();
+  const mail = captureMailer();
+  const first = makeDeps(mail);
   expect(await sendBroadcast(db, first.deps, { broadcastId })).toBe("sent");
   expect(first.enqueued).toHaveLength(2);
 
@@ -233,15 +258,16 @@ it("re-running a fan-out never double-sends: no duplicate rows or jobs", async (
     .update(schema.broadcasts)
     .set({ status: "sending" })
     .where(eq(schema.broadcasts.id, broadcastId));
-  const second = makeDeps();
+  const second = makeDeps(mail);
   expect(await sendBroadcast(db, second.deps, { broadcastId })).toBe("sent");
   expect(await emailsOf(broadcastId)).toHaveLength(2);
   // Conflicted rows enqueue nothing — their jobs already exist.
   expect(second.enqueued).toHaveLength(0);
 
   // A completed broadcast is a no-op.
-  const third = makeDeps();
+  const third = makeDeps(mail);
   expect(await sendBroadcast(db, third.deps, { broadcastId })).toBe("skipped");
+  expect(mail.sends.map((s) => s.kind)).toEqual(["broadcast.sent"]);
 });
 
 it("broadcast emails carry RFC 8058 headers through the SES send", async () => {
@@ -367,9 +393,19 @@ it("cloud fan-out reserves daily quota and parks the overflow as queued_quota", 
     teamId: qTeamId,
     from: "Acme <hi@quota.dev>",
   });
-  const { deps, enqueued } = makeDeps({ isCloud: true });
+  const mail = captureMailer();
+  const { deps, enqueued } = makeDeps({ isCloud: true, ...mail });
 
   expect(await sendBroadcast(db, deps, { broadcastId })).toBe("sent");
+  // Anything parked turns the report into the quota notice.
+  expect(mail.sends.map((s) => [s.to, s.subject])).toEqual([
+    ["quota-owner@example.com", '"launch": 1 of 3 recipients are waiting for the quota'],
+  ]);
+  expect(mail.sends[0]?.text).toContain(
+    "2 emails went out; 1 are parked because quota reached its daily quota of 100.",
+  );
+  expect(mail.sends[0]?.text).toContain("after the reset at 00:00 UTC");
+  expect(mail.sends[0]?.text).toContain(`${BASE_URL}/settings/billing`);
 
   const rows = await emailsOf(broadcastId);
   expect(rows).toHaveLength(3);
@@ -924,13 +960,20 @@ it("defers the fan-out while the sender domain's region is held by the platform 
   await db.insert(schema.regionBreakers).values({ region: "us-east-1", paused: true });
   const broadcastId = await insertBroadcast();
   const rescheduled: Date[] = [];
+  const mail = captureMailer();
   const { deps, enqueued } = makeDeps({
     reschedule: async (_id, at) => {
       rescheduled.push(at);
     },
+    ...mail,
   });
   expect(await sendBroadcast(db, deps, { broadcastId })).toBe("deferred");
-  expect(rescheduled).toHaveLength(1);
+  // Said once, however many waits the hold lasts.
+  expect(await sendBroadcast(db, deps, { broadcastId })).toBe("deferred");
+  expect(rescheduled).toHaveLength(2);
+  expect(mail.sends.map((s) => s.subject)).toEqual(['"launch" is on hold']);
+  expect(mail.sends[0]?.text).toContain("Sending from us-east-1 is paused");
+  expect(mail.sends[0]?.text).toContain(`${BASE_URL}/broadcasts/${broadcastId}`);
   expect(enqueued).toEqual([]);
   const [row] = await db
     .select({ status: schema.broadcasts.status })

--- a/packages/billing/src/subscription.ts
+++ b/packages/billing/src/subscription.ts
@@ -85,6 +85,7 @@ export async function applySubscription(
       planStatus: planStatusOf(sub.status),
       stripeSubscriptionId: sub.id,
       currentPeriodEnd: periodEnd(sub),
+      cancelAt: sub.cancel_at ? new Date(sub.cancel_at * 1000) : null,
     })
     .where(eq(schema.teams.id, team.id));
 }
@@ -142,6 +143,7 @@ export async function cancelTeamSubscription(deps: BillingDeps, teamId: string):
       planStatus: "canceled",
       stripeSubscriptionId: null,
       currentPeriodEnd: null,
+      cancelAt: null,
     })
     .where(eq(schema.teams.id, teamId));
 }

--- a/packages/billing/test/webhook.test.ts
+++ b/packages/billing/test/webhook.test.ts
@@ -269,6 +269,32 @@ describe("handleWebhook", () => {
     });
   });
 
+  it("mirrors Stripe's cancel_at and clears it once the cancellation is undone", async () => {
+    const teamId = await createTeam(db, "acme");
+    await db
+      .update(schema.teams)
+      .set({ stripeCustomerId: "cus_1" })
+      .where(eq(schema.teams.id, teamId));
+    const scheduled = { ...subscription("sub_1", "cus_1", "active"), cancel_at: 1_900_000_000 };
+    subscriptions.sub_1 = scheduled as Stripe.Subscription;
+    expect(
+      await deliver(event("customer.subscription.updated", { id: "sub_1", customer: "cus_1" })),
+    ).toBe(200);
+    const cancelAt = async () =>
+      (
+        await db
+          .select({ cancelAt: schema.teams.cancelAt })
+          .from(schema.teams)
+          .where(eq(schema.teams.id, teamId))
+      )[0]?.cancelAt;
+    expect((await cancelAt())?.toISOString()).toBe(new Date(1_900_000_000 * 1000).toISOString());
+    subscriptions.sub_1 = subscription("sub_1", "cus_1", "active");
+    expect(
+      await deliver(event("customer.subscription.updated", { id: "sub_1", customer: "cus_1" })),
+    ).toBe(200);
+    expect(await cancelAt()).toBeNull();
+  });
+
   it("ignores the end of a superseded subscription", async () => {
     const teamId = await customerTeam();
     subscriptions.sub_old = subscription("sub_old", "cus_1", "canceled");

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -39,6 +39,10 @@
     "./plans": {
       "types": "./src/plans.ts",
       "default": "./src/plans.ts"
+    },
+    "./mail-preferences": {
+      "types": "./src/mail-preferences.ts",
+      "default": "./src/mail-preferences.ts"
     }
   },
   "scripts": {

--- a/packages/core/src/account-mail.ts
+++ b/packages/core/src/account-mail.ts
@@ -1,0 +1,87 @@
+import { en } from "./account-mail/en.js";
+import { ptBR } from "./account-mail/pt-BR.js";
+import { accountMailCard, fillTemplate } from "./html.js";
+
+/** The languages account mail is written in; the dashboard's own two. */
+export const MAIL_LOCALES = ["en", "pt-BR"] as const;
+export type MailLocale = (typeof MAIL_LOCALES)[number];
+
+export function isMailLocale(value: unknown): value is MailLocale {
+  return typeof value === "string" && (MAIL_LOCALES as readonly string[]).includes(value);
+}
+
+/** Every email the instance sends about accounts, teams, billing and sends. */
+export const ACCOUNT_MAIL_KINDS = [
+  "welcome",
+  "password_changed",
+  "mcp.connected",
+  "api_key.created",
+  "webhook.secret_rotated",
+  "member.joined",
+  "domain.verified",
+  "domain.lost",
+  "domain.lost.identity",
+  "broadcast.sent",
+  "broadcast.held_quota",
+  "broadcast.held",
+  "billing.payment_failed",
+  "billing.plan_activated",
+  "billing.plan_changed",
+  "billing.cancel_scheduled",
+  "billing.cancel_reminder",
+  "billing.downgraded",
+] as const;
+export type AccountMailKind = (typeof ACCOUNT_MAIL_KINDS)[number];
+
+/** One catalog entry: `{slot}` placeholders are filled from the caller's values. */
+export interface AccountMailEntry {
+  subject: string;
+  body: string[];
+  button: string;
+  muted?: string[];
+  /** Sentences a caller picks by key and fills in as a value, e.g. a payment's retry line. */
+  extra?: Record<string, string>;
+}
+
+export interface MailContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+const CATALOGS: Record<MailLocale, Record<AccountMailKind, AccountMailEntry>> = {
+  en,
+  "pt-BR": ptBR,
+};
+
+/** A phrase from an entry's `extra`, filled; the caller passes it back in as a value. */
+export function accountMailPhrase(input: {
+  locale: MailLocale;
+  kind: AccountMailKind;
+  key: string;
+  values?: Record<string, string>;
+}): string {
+  const phrase = CATALOGS[input.locale][input.kind].extra?.[input.key];
+  if (phrase === undefined) throw new Error(`no phrase ${input.key} for ${input.kind}`);
+  return fillTemplate(phrase, input.values ?? {});
+}
+
+/** Renders one kind in one language on the shared card; `url` is the button's target. */
+export function buildAccountMail(input: {
+  kind: AccountMailKind;
+  locale: MailLocale;
+  url: string;
+  values?: Record<string, string>;
+}): MailContent {
+  const entry = CATALOGS[input.locale][input.kind];
+  const values = input.values ?? {};
+  return {
+    subject: fillTemplate(entry.subject, values),
+    ...accountMailCard({
+      paragraphs: entry.body.map((p) => fillTemplate(p, values)),
+      button: fillTemplate(entry.button, values),
+      url: input.url,
+      muted: (entry.muted ?? []).map((m) => fillTemplate(m, values)),
+    }),
+  };
+}

--- a/packages/core/src/account-mail.ts
+++ b/packages/core/src/account-mail.ts
@@ -78,6 +78,76 @@ export function formatMailDate(locale: MailLocale, date: Date): string {
   return new Intl.DateTimeFormat(locale, { dateStyle: "long", timeZone: "UTC" }).format(date);
 }
 
+/** Days ahead of a scheduled cancellation at which owners are reminded. */
+export const CANCEL_REMINDER_DAYS = 3;
+
+export interface PlanSnapshot {
+  plan: Plan;
+  currentPeriodEnd: Date | null;
+  cancelAt: Date | null;
+}
+
+export interface PlanMove {
+  kind: "billing.plan_activated" | "billing.plan_changed" | "billing.downgraded";
+  /** Claim key every surface computes alike, so the first to notice is the one that speaks. */
+  periodKey: string;
+  values: (locale: MailLocale, team: string) => Record<string, string>;
+}
+
+/**
+ * What a team's owners hear when its plan moved from `before` to `after`,
+ * read off the team row rather than the event, so the Stripe webhook, the
+ * daily reconcile and the grace sweep agree on the mail and on its claim.
+ */
+export function planMove(
+  before: PlanSnapshot,
+  after: PlanSnapshot,
+  now: Date = new Date(),
+): PlanMove | null {
+  const freeCap = (locale: MailLocale) => (PLAN_DAILY_LIMIT.free ?? 0).toLocaleString(locale);
+  if (before.plan !== "free" && after.plan === "free") {
+    // The plan cannot have outlived a scheduled cancellation, its period, or today.
+    const ended = [before.cancelAt, before.currentPeriodEnd, now]
+      .filter((d): d is Date => d !== null)
+      .reduce((a, b) => (a < b ? a : b));
+    return {
+      kind: "billing.downgraded",
+      periodKey: before.currentPeriodEnd?.toISOString() ?? "none",
+      values: (locale, team) => ({
+        team,
+        plan: PLAN_NAME[before.plan],
+        date: formatMailDate(locale, ended),
+        freeCap: freeCap(locale),
+      }),
+    };
+  }
+  const period = after.currentPeriodEnd?.toISOString() ?? "none";
+  if (before.plan === "free" && after.plan !== "free") {
+    return {
+      kind: "billing.plan_activated",
+      periodKey: `${after.plan}:${period}`,
+      values: (locale, team) => ({
+        team,
+        plan: PLAN_NAME[after.plan],
+        cap: planCapPhrase(locale, after.plan),
+      }),
+    };
+  }
+  if (before.plan !== after.plan) {
+    return {
+      kind: "billing.plan_changed",
+      periodKey: `${before.plan}>${after.plan}:${period}`,
+      values: (locale, team) => ({
+        team,
+        old: PLAN_NAME[before.plan],
+        new: PLAN_NAME[after.plan],
+        cap: planCapPhrase(locale, after.plan),
+      }),
+    };
+  }
+  return null;
+}
+
 /** A moment in the reader's language, said in UTC so two readers agree on it. */
 export function formatMailDateTime(locale: MailLocale, date: Date): string {
   const at = new Intl.DateTimeFormat(locale, {

--- a/packages/core/src/account-mail.ts
+++ b/packages/core/src/account-mail.ts
@@ -1,6 +1,7 @@
-import { en } from "./account-mail/en.js";
-import { ptBR } from "./account-mail/pt-BR.js";
+import { en, enPhrases } from "./account-mail/en.js";
+import { ptBR, ptBRPhrases } from "./account-mail/pt-BR.js";
 import { accountMailCard, fillTemplate } from "./html.js";
+import { PLAN_DAILY_LIMIT, type Plan } from "./plans.js";
 
 /** The languages account mail is written in; the dashboard's own two. */
 export const MAIL_LOCALES = ["en", "pt-BR"] as const;
@@ -53,6 +54,29 @@ const CATALOGS: Record<MailLocale, Record<AccountMailKind, AccountMailEntry>> = 
   en,
   "pt-BR": ptBR,
 };
+
+export type MailPhraseKey = "capUpTo" | "capNone";
+
+const PHRASES: Record<MailLocale, Record<MailPhraseKey, string>> = {
+  en: enPhrases,
+  "pt-BR": ptBRPhrases,
+};
+
+/** Plan names as the mails say them: the same word in every language. */
+export const PLAN_NAME: Record<Plan, string> = { free: "Free", pro: "Pro", scale: "Scale" };
+
+/** What a plan lets a team send, as a clause: "up to 3,000 emails a day", or the no-cap phrase. */
+export function planCapPhrase(locale: MailLocale, plan: Plan): string {
+  const limit = PLAN_DAILY_LIMIT[plan];
+  return limit === null
+    ? PHRASES[locale].capNone
+    : fillTemplate(PHRASES[locale].capUpTo, { n: limit.toLocaleString(locale) });
+}
+
+/** A calendar date in the reader's language, on the UTC day billing and quotas run on. */
+export function formatMailDate(locale: MailLocale, date: Date): string {
+  return new Intl.DateTimeFormat(locale, { dateStyle: "long", timeZone: "UTC" }).format(date);
+}
 
 /** A phrase from an entry's `extra`, filled; the caller passes it back in as a value. */
 export function accountMailPhrase(input: {

--- a/packages/core/src/account-mail.ts
+++ b/packages/core/src/account-mail.ts
@@ -78,6 +78,16 @@ export function formatMailDate(locale: MailLocale, date: Date): string {
   return new Intl.DateTimeFormat(locale, { dateStyle: "long", timeZone: "UTC" }).format(date);
 }
 
+/** A moment in the reader's language, said in UTC so two readers agree on it. */
+export function formatMailDateTime(locale: MailLocale, date: Date): string {
+  const at = new Intl.DateTimeFormat(locale, {
+    dateStyle: "long",
+    timeStyle: "short",
+    timeZone: "UTC",
+  }).format(date);
+  return `${at} UTC`;
+}
+
 /** A phrase from an entry's `extra`, filled; the caller passes it back in as a value. */
 export function accountMailPhrase(input: {
   locale: MailLocale;

--- a/packages/core/src/account-mail/en.ts
+++ b/packages/core/src/account-mail/en.ts
@@ -1,0 +1,166 @@
+import type { AccountMailEntry, AccountMailKind } from "../account-mail.js";
+
+export const en = {
+  welcome: {
+    subject: "Welcome to MillionSend",
+    body: [
+      "Hi {name}, your account is ready.",
+      "First add a sending domain and publish its DNS records; sends go out the moment it verifies.",
+      "Then create an API key under API keys — it is shown once, and it is what the SDKs, SMTP and the MCP server send with.",
+    ],
+    button: "Add a domain",
+    muted: ["Docs: {docsUrl}"],
+  },
+  password_changed: {
+    subject: "Your MillionSend password was changed",
+    body: [
+      "The password for {email} was just changed and every other session was signed out.",
+      "If this was you, nothing to do. If it wasn't, reset it now — that signs out whoever did it — and review your API keys and connected apps.",
+    ],
+    button: "Reset password",
+  },
+  "mcp.connected": {
+    subject: "{app} is connected to your MillionSend account",
+    body: [
+      "You allowed {app} to act on {team} through the MillionSend MCP server with these permissions: {scopes}.",
+      "It can do there what you can do, in your name, until you revoke it.",
+    ],
+    button: "Review connected apps",
+    muted: ["Didn't authorize this? Revoke it now."],
+    extra: { allTeams: "all your teams" },
+  },
+  "api_key.created": {
+    subject: "New API key in {team}: {name}",
+    body: [
+      '{actor} created the API key "{name}" ({prefix}…{last4}, {permission}{scope}) in {team}.',
+      "Anyone holding it can send from the team's verified domains. Not expected? Revoke it under API keys.",
+    ],
+    button: "Open API keys",
+    extra: {
+      scope: ", limited to {domain}",
+      full_access: "full access",
+      sending_access: "sending access",
+      apiKeyActor: "an API key",
+      mcpActor: "an MCP client",
+      systemActor: "MillionSend",
+    },
+  },
+  "webhook.secret_rotated": {
+    subject: "Webhook secret rotated for {host}",
+    body: [
+      "{actor} rotated the signing secret of {url} in {team}.",
+      "The previous secret keeps verifying until {until}; switch the receiver before then or its deliveries start failing.",
+    ],
+    button: "Open the endpoint",
+    extra: { immediately: "now — it stopped verifying immediately" },
+  },
+  "member.joined": {
+    subject: "{name} joined {team}",
+    body: [
+      "{name} ({email}) accepted the invitation and is now {role} of {team}.",
+      "Members send and read logs; admins also manage domains, keys and webhooks. Remove them under Settings → Team if that's wrong.",
+    ],
+    button: "Open team settings",
+    extra: { member: "a member", admin: "an admin", owner: "an owner" },
+  },
+  "domain.verified": {
+    subject: "{domain} is verified",
+    body: [
+      "The DNS records for {domain} check out and it can send from any address on it — API, SMTP and broadcasts.",
+      "We keep re-checking the records and will tell you if one disappears.",
+    ],
+    button: "Open domain",
+  },
+  "domain.lost": {
+    subject: "{domain} lost its verification",
+    body: [
+      "A required DNS record for {domain} (DKIM or MAIL FROM) no longer resolves, so sends from it are refused until it's back — API calls fail and scheduled broadcasts stop at send time.",
+      "Restore the record at your DNS host; verification returns on its own at the next check or when you press Verify.",
+    ],
+    button: "Open domain",
+  },
+  "domain.lost.identity": {
+    subject: "{domain} lost its verification",
+    body: [
+      "The SES identity for {domain} no longer exists, so sends from it are refused. Add the domain again to keep sending from it.",
+    ],
+    button: "Open domains",
+  },
+  "broadcast.sent": {
+    subject: '"{name}" went out to {count} recipients',
+    body: [
+      '"{subject}" was handed to {count} contacts of {team}; suppressed and unsubscribed addresses were skipped.',
+      "Opens, clicks and bounces appear on the broadcast page as they arrive.",
+    ],
+    button: "Open broadcast",
+  },
+  "broadcast.held_quota": {
+    subject: '"{name}": {parked} of {count} recipients are waiting for the quota',
+    body: [
+      "{sent} emails went out; {parked} are parked because {team} reached its daily quota of {limit}.",
+      "They go out after the reset at {resetsAt} UTC, or within minutes of a higher plan.",
+    ],
+    button: "Review your plan",
+  },
+  "broadcast.held": {
+    subject: '"{name}" is on hold',
+    body: [
+      'Sending from {region} is paused across the platform while bounce and complaint rates settle, so "{name}" waits instead of going out; transactional email keeps flowing.',
+      "It resumes by itself — we re-check every 15 minutes — and you'll get the usual sent report when it's done.",
+    ],
+    button: "Open broadcast",
+  },
+  "billing.payment_failed": {
+    subject: "Payment failed for {team}'s {plan} plan",
+    body: [
+      "We couldn't charge the card on file for {team}'s {plan} plan.",
+      "{retry} Until then nothing changes and the daily cap stays at {cap}. If the retries keep failing, Stripe cancels the subscription and {team} returns to Free ({freeCap} emails a day).",
+    ],
+    button: "Pay the invoice",
+    muted: ["Or update the card from Billing: {billingUrl}"],
+    extra: {
+      retryOn: "Stripe retries on {date}.",
+      noRetry: "Stripe is not retrying on its own.",
+    },
+  },
+  "billing.plan_activated": {
+    subject: "{team} is on {plan}",
+    body: [
+      "Your subscription is active: {team} now sends up to {cap} emails a day, and anything parked over the old cap is released within minutes.",
+      "Receipts and invoices come from Stripe; the subscription is managed from Billing.",
+    ],
+    button: "Open billing",
+  },
+  "billing.plan_changed": {
+    subject: "{team} moved from {old} to {new}",
+    body: [
+      "From now on {team} sends up to {cap} emails a day. On a lower cap, sends already accepted are unaffected; anything over the new cap waits for the next UTC day.",
+      "Proration shows on the next Stripe invoice.",
+    ],
+    button: "Open billing",
+  },
+  "billing.cancel_scheduled": {
+    subject: "Your {plan} plan ends on {date}",
+    body: [
+      "{team} stays on {plan} until {date}; after that it returns to Free ({freeCap} emails a day).",
+      "Changed your mind? Resume the plan from Billing before then and nothing changes.",
+    ],
+    button: "Open billing",
+  },
+  "billing.cancel_reminder": {
+    subject: "{team}'s {plan} plan ends in 3 days",
+    body: [
+      "On {date} {team} returns to Free: {freeCap} emails a day, and anything over the cap waits for the next day.",
+      "Resume the plan from Billing to keep {cap}.",
+    ],
+    button: "Open billing",
+  },
+  "billing.downgraded": {
+    subject: "{team} is now on Free",
+    body: [
+      "The {plan} plan ended on {date}. From today {team} sends up to {freeCap} emails a day; anything over waits for the next UTC day, and broadcasts over the cap go out in parts.",
+      "Verified domains, contacts and API keys are untouched. Pick a plan again from Billing whenever you need more.",
+    ],
+    button: "Open billing",
+  },
+} as const satisfies Record<AccountMailKind, AccountMailEntry>;

--- a/packages/core/src/account-mail/en.ts
+++ b/packages/core/src/account-mail/en.ts
@@ -47,12 +47,14 @@ export const en = {
   },
   "webhook.secret_rotated": {
     subject: "Webhook secret rotated for {host}",
-    body: [
-      "{actor} rotated the signing secret of {url} in {team}.",
-      "The previous secret keeps verifying until {until}; switch the receiver before then or its deliveries start failing.",
-    ],
+    body: ["{actor} rotated the signing secret of {url} in {team}.", "{deadline}"],
     button: "Open the endpoint",
-    extra: { immediately: "now — it stopped verifying immediately" },
+    extra: {
+      overlap:
+        "The previous secret keeps verifying until {until}; switch the receiver before then or its deliveries start failing.",
+      immediately:
+        "The previous secret stopped verifying at once; deliveries fail until the receiver uses the new one.",
+    },
   },
   "member.joined": {
     subject: "{name} joined {team}",
@@ -114,7 +116,7 @@ export const en = {
     subject: "Payment failed for {team}'s {plan} plan",
     body: [
       "We couldn't charge the card on file for {team}'s {plan} plan.",
-      "{retry} Until then nothing changes and {team} keeps sending {cap}. If the retries keep failing, Stripe cancels the subscription and {team} returns to Free ({freeCap} emails a day).",
+      "{retry} Nothing changes yet: {team} keeps sending {cap}. If the invoice stays unpaid, Stripe cancels the subscription and {team} returns to Free ({freeCap} emails a day).",
     ],
     button: "Pay the invoice",
     muted: ["Or update the card from Billing: {billingUrl}"],
@@ -148,7 +150,7 @@ export const en = {
     button: "Open billing",
   },
   "billing.cancel_reminder": {
-    subject: "{team}'s {plan} plan ends in 3 days",
+    subject: "Reminder: {team}'s {plan} plan ends on {date}",
     body: [
       "On {date} {team} returns to Free: {freeCap} emails a day, and anything over the cap waits for the next day.",
       "Resume the plan from Billing to keep sending {cap}.",

--- a/packages/core/src/account-mail/en.ts
+++ b/packages/core/src/account-mail/en.ts
@@ -1,4 +1,4 @@
-import type { AccountMailEntry, AccountMailKind } from "../account-mail.js";
+import type { AccountMailEntry, AccountMailKind, MailPhraseKey } from "../account-mail.js";
 
 export const en = {
   welcome: {
@@ -114,7 +114,7 @@ export const en = {
     subject: "Payment failed for {team}'s {plan} plan",
     body: [
       "We couldn't charge the card on file for {team}'s {plan} plan.",
-      "{retry} Until then nothing changes and the daily cap stays at {cap}. If the retries keep failing, Stripe cancels the subscription and {team} returns to Free ({freeCap} emails a day).",
+      "{retry} Until then nothing changes and {team} keeps sending {cap}. If the retries keep failing, Stripe cancels the subscription and {team} returns to Free ({freeCap} emails a day).",
     ],
     button: "Pay the invoice",
     muted: ["Or update the card from Billing: {billingUrl}"],
@@ -126,7 +126,7 @@ export const en = {
   "billing.plan_activated": {
     subject: "{team} is on {plan}",
     body: [
-      "Your subscription is active: {team} now sends up to {cap} emails a day, and anything parked over the old cap is released within minutes.",
+      "Your subscription is active: {team} now sends {cap}, and anything parked over the old cap is released within minutes.",
       "Receipts and invoices come from Stripe; the subscription is managed from Billing.",
     ],
     button: "Open billing",
@@ -134,7 +134,7 @@ export const en = {
   "billing.plan_changed": {
     subject: "{team} moved from {old} to {new}",
     body: [
-      "From now on {team} sends up to {cap} emails a day. On a lower cap, sends already accepted are unaffected; anything over the new cap waits for the next UTC day.",
+      "From now on {team} sends {cap}. On a lower cap, sends already accepted are unaffected; anything over the new cap waits for the next UTC day.",
       "Proration shows on the next Stripe invoice.",
     ],
     button: "Open billing",
@@ -151,7 +151,7 @@ export const en = {
     subject: "{team}'s {plan} plan ends in 3 days",
     body: [
       "On {date} {team} returns to Free: {freeCap} emails a day, and anything over the cap waits for the next day.",
-      "Resume the plan from Billing to keep {cap}.",
+      "Resume the plan from Billing to keep sending {cap}.",
     ],
     button: "Open billing",
   },
@@ -164,3 +164,9 @@ export const en = {
     button: "Open billing",
   },
 } as const satisfies Record<AccountMailKind, AccountMailEntry>;
+
+/** Sentences several kinds share, filled by the builders. */
+export const enPhrases = {
+  capUpTo: "up to {n} emails a day",
+  capNone: "with no daily cap",
+} as const satisfies Record<MailPhraseKey, string>;

--- a/packages/core/src/account-mail/en.ts
+++ b/packages/core/src/account-mail/en.ts
@@ -82,7 +82,7 @@ export const en = {
   "domain.lost.identity": {
     subject: "{domain} lost its verification",
     body: [
-      "The SES identity for {domain} no longer exists, so sends from it are refused. Add the domain again to keep sending from it.",
+      "SES has given up on {domain}: its identity is gone, or its DKIM records stayed missing past the 72-hour window. Sends from it are refused; add the domain again to keep sending from it.",
     ],
     button: "Open domains",
   },

--- a/packages/core/src/account-mail/pt-BR.ts
+++ b/packages/core/src/account-mail/pt-BR.ts
@@ -47,12 +47,14 @@ export const ptBR = {
   },
   "webhook.secret_rotated": {
     subject: "Segredo do webhook {host} rotacionado",
-    body: [
-      "{actor} rotacionou o segredo de assinatura de {url} em {team}.",
-      "O segredo anterior continua válido até {until}; troque no receptor antes disso ou as entregas passam a falhar.",
-    ],
+    body: ["{actor} rotacionou o segredo de assinatura de {url} em {team}.", "{deadline}"],
     button: "Abrir endpoint",
-    extra: { immediately: "agora — ele deixou de valer imediatamente" },
+    extra: {
+      overlap:
+        "O segredo anterior continua válido até {until}; troque no receptor antes disso ou as entregas passam a falhar.",
+      immediately:
+        "O segredo anterior deixou de valer na hora; as entregas falham até o receptor usar o novo.",
+    },
   },
   "member.joined": {
     subject: "{name} entrou em {team}",
@@ -114,7 +116,7 @@ export const ptBR = {
     subject: "Pagamento recusado no plano {plan} de {team}",
     body: [
       "Não conseguimos cobrar o cartão cadastrado do plano {plan} de {team}.",
-      "{retry} Até lá nada muda e {team} continua enviando {cap}. Se as tentativas continuarem falhando, a Stripe cancela a assinatura e {team} volta ao Free ({freeCap} e-mails por dia).",
+      "{retry} Por enquanto nada muda: {team} continua enviando {cap}. Se a fatura continuar em aberto, a Stripe cancela a assinatura e {team} volta ao Free ({freeCap} e-mails por dia).",
     ],
     button: "Pagar fatura",
     muted: ["Ou atualize o cartão em Cobrança: {billingUrl}"],
@@ -148,7 +150,7 @@ export const ptBR = {
     button: "Abrir cobrança",
   },
   "billing.cancel_reminder": {
-    subject: "O plano {plan} de {team} termina em 3 dias",
+    subject: "Lembrete: o plano {plan} de {team} termina em {date}",
     body: [
       "Em {date} {team} volta ao Free: {freeCap} e-mails por dia, e o que passar do limite espera o dia seguinte.",
       "Retome o plano em Cobrança para continuar enviando {cap}.",

--- a/packages/core/src/account-mail/pt-BR.ts
+++ b/packages/core/src/account-mail/pt-BR.ts
@@ -1,0 +1,166 @@
+import type { AccountMailEntry, AccountMailKind } from "../account-mail.js";
+
+export const ptBR = {
+  welcome: {
+    subject: "Bem-vindo ao MillionSend",
+    body: [
+      "Olá, {name}, sua conta está pronta.",
+      "Primeiro adicione um domínio de envio e publique os registros DNS; os envios saem assim que ele verificar.",
+      "Depois crie uma chave de API em Chaves de API — ela aparece uma única vez e é o que os SDKs, o SMTP e o servidor MCP usam para enviar.",
+    ],
+    button: "Adicionar domínio",
+    muted: ["Documentação: {docsUrl}"],
+  },
+  password_changed: {
+    subject: "Sua senha do MillionSend foi alterada",
+    body: [
+      "A senha de {email} acabou de ser alterada e as outras sessões foram encerradas.",
+      "Se foi você, não há nada a fazer. Se não foi, redefina agora — isso encerra a sessão de quem fez — e revise suas chaves de API e apps conectados.",
+    ],
+    button: "Redefinir senha",
+  },
+  "mcp.connected": {
+    subject: "{app} foi conectado à sua conta do MillionSend",
+    body: [
+      "Você permitiu que {app} atue em {team} pelo servidor MCP do MillionSend com estas permissões: {scopes}.",
+      "Ele pode fazer ali o que você pode, em seu nome, até você revogar.",
+    ],
+    button: "Revisar apps conectados",
+    muted: ["Não autorizou isso? Revogue agora."],
+    extra: { allTeams: "todas as suas equipes" },
+  },
+  "api_key.created": {
+    subject: "Nova chave de API em {team}: {name}",
+    body: [
+      '{actor} criou a chave de API "{name}" ({prefix}…{last4}, {permission}{scope}) em {team}.',
+      "Quem tiver a chave pode enviar pelos domínios verificados da equipe. Não esperava isso? Revogue em Chaves de API.",
+    ],
+    button: "Abrir chaves de API",
+    extra: {
+      scope: ", limitada a {domain}",
+      full_access: "acesso total",
+      sending_access: "acesso de envio",
+      apiKeyActor: "uma chave de API",
+      mcpActor: "um cliente MCP",
+      systemActor: "o MillionSend",
+    },
+  },
+  "webhook.secret_rotated": {
+    subject: "Segredo do webhook {host} rotacionado",
+    body: [
+      "{actor} rotacionou o segredo de assinatura de {url} em {team}.",
+      "O segredo anterior continua válido até {until}; troque no receptor antes disso ou as entregas passam a falhar.",
+    ],
+    button: "Abrir endpoint",
+    extra: { immediately: "agora — ele deixou de valer imediatamente" },
+  },
+  "member.joined": {
+    subject: "{name} entrou em {team}",
+    body: [
+      "{name} ({email}) aceitou o convite e agora é {role} de {team}.",
+      "Membros enviam e leem os logs; administradores também gerenciam domínios, chaves e webhooks. Remova em Configurações → Equipe se estiver errado.",
+    ],
+    button: "Abrir configurações da equipe",
+    extra: { member: "membro", admin: "administrador", owner: "proprietário" },
+  },
+  "domain.verified": {
+    subject: "{domain} está verificado",
+    body: [
+      "Os registros DNS de {domain} estão corretos e ele pode enviar de qualquer endereço — API, SMTP e broadcasts.",
+      "Continuamos verificando os registros e avisamos se algum sumir.",
+    ],
+    button: "Abrir domínio",
+  },
+  "domain.lost": {
+    subject: "{domain} perdeu a verificação",
+    body: [
+      "Um registro DNS obrigatório de {domain} (DKIM ou MAIL FROM) deixou de responder, então os envios são recusados até ele voltar — chamadas à API falham e broadcasts agendados param na hora do envio.",
+      "Restaure o registro no seu DNS; a verificação volta sozinha na próxima checagem ou quando você clicar em Verificar.",
+    ],
+    button: "Abrir domínio",
+  },
+  "domain.lost.identity": {
+    subject: "{domain} perdeu a verificação",
+    body: [
+      "A identidade SES de {domain} não existe mais, então os envios são recusados. Adicione o domínio de novo para voltar a enviar.",
+    ],
+    button: "Abrir domínios",
+  },
+  "broadcast.sent": {
+    subject: '"{name}" foi enviado para {count} destinatários',
+    body: [
+      '"{subject}" foi entregue a {count} contatos de {team}; endereços suprimidos e descadastrados foram ignorados.',
+      "Aberturas, cliques e bounces aparecem na página do broadcast conforme chegam.",
+    ],
+    button: "Abrir broadcast",
+  },
+  "broadcast.held_quota": {
+    subject: '"{name}": {parked} de {count} destinatários aguardam a cota',
+    body: [
+      "{sent} e-mails saíram; {parked} estão retidos porque {team} atingiu a cota diária de {limit}.",
+      "Eles saem após a virada às {resetsAt} UTC, ou minutos depois de um plano maior.",
+    ],
+    button: "Revisar plano",
+  },
+  "broadcast.held": {
+    subject: '"{name}" está em espera',
+    body: [
+      'Os envios de {region} estão pausados em toda a plataforma enquanto as taxas de bounce e reclamação se estabilizam, então "{name}" aguarda em vez de sair; e-mails transacionais continuam saindo.',
+      "Ele retoma sozinho — checamos a cada 15 minutos — e você recebe o relatório de envio de sempre ao terminar.",
+    ],
+    button: "Abrir broadcast",
+  },
+  "billing.payment_failed": {
+    subject: "Pagamento recusado no plano {plan} de {team}",
+    body: [
+      "Não conseguimos cobrar o cartão cadastrado do plano {plan} de {team}.",
+      "{retry} Até lá nada muda e o limite diário continua em {cap}. Se as tentativas continuarem falhando, a Stripe cancela a assinatura e {team} volta ao Free ({freeCap} e-mails por dia).",
+    ],
+    button: "Pagar fatura",
+    muted: ["Ou atualize o cartão em Cobrança: {billingUrl}"],
+    extra: {
+      retryOn: "A Stripe tenta de novo em {date}.",
+      noRetry: "A Stripe não vai tentar de novo sozinha.",
+    },
+  },
+  "billing.plan_activated": {
+    subject: "{team} está no plano {plan}",
+    body: [
+      "Sua assinatura está ativa: {team} agora envia até {cap} e-mails por dia, e o que estava retido acima do limite antigo é liberado em minutos.",
+      "Recibos e faturas vêm da Stripe; a assinatura é gerenciada em Cobrança.",
+    ],
+    button: "Abrir cobrança",
+  },
+  "billing.plan_changed": {
+    subject: "{team} mudou de {old} para {new}",
+    body: [
+      "A partir de agora {team} envia até {cap} e-mails por dia. Num limite menor, os envios já aceitos não mudam; o que passar do novo limite espera o próximo dia UTC.",
+      "O rateio aparece na próxima fatura da Stripe.",
+    ],
+    button: "Abrir cobrança",
+  },
+  "billing.cancel_scheduled": {
+    subject: "Seu plano {plan} termina em {date}",
+    body: [
+      "{team} continua no {plan} até {date}; depois volta ao Free ({freeCap} e-mails por dia).",
+      "Mudou de ideia? Retome o plano em Cobrança antes disso e nada muda.",
+    ],
+    button: "Abrir cobrança",
+  },
+  "billing.cancel_reminder": {
+    subject: "O plano {plan} de {team} termina em 3 dias",
+    body: [
+      "Em {date} {team} volta ao Free: {freeCap} e-mails por dia, e o que passar do limite espera o dia seguinte.",
+      "Retome o plano em Cobrança para manter {cap}.",
+    ],
+    button: "Abrir cobrança",
+  },
+  "billing.downgraded": {
+    subject: "{team} agora está no Free",
+    body: [
+      "O plano {plan} terminou em {date}. A partir de hoje {team} envia até {freeCap} e-mails por dia; o que passar espera o próximo dia UTC, e broadcasts acima do limite saem em partes.",
+      "Domínios verificados, contatos e chaves de API continuam iguais. Escolha um plano de novo em Cobrança quando precisar de mais.",
+    ],
+    button: "Abrir cobrança",
+  },
+} as const satisfies Record<AccountMailKind, AccountMailEntry>;

--- a/packages/core/src/account-mail/pt-BR.ts
+++ b/packages/core/src/account-mail/pt-BR.ts
@@ -1,4 +1,4 @@
-import type { AccountMailEntry, AccountMailKind } from "../account-mail.js";
+import type { AccountMailEntry, AccountMailKind, MailPhraseKey } from "../account-mail.js";
 
 export const ptBR = {
   welcome: {
@@ -114,7 +114,7 @@ export const ptBR = {
     subject: "Pagamento recusado no plano {plan} de {team}",
     body: [
       "Não conseguimos cobrar o cartão cadastrado do plano {plan} de {team}.",
-      "{retry} Até lá nada muda e o limite diário continua em {cap}. Se as tentativas continuarem falhando, a Stripe cancela a assinatura e {team} volta ao Free ({freeCap} e-mails por dia).",
+      "{retry} Até lá nada muda e {team} continua enviando {cap}. Se as tentativas continuarem falhando, a Stripe cancela a assinatura e {team} volta ao Free ({freeCap} e-mails por dia).",
     ],
     button: "Pagar fatura",
     muted: ["Ou atualize o cartão em Cobrança: {billingUrl}"],
@@ -126,7 +126,7 @@ export const ptBR = {
   "billing.plan_activated": {
     subject: "{team} está no plano {plan}",
     body: [
-      "Sua assinatura está ativa: {team} agora envia até {cap} e-mails por dia, e o que estava retido acima do limite antigo é liberado em minutos.",
+      "Sua assinatura está ativa: {team} agora envia {cap}, e o que estava retido acima do limite antigo é liberado em minutos.",
       "Recibos e faturas vêm da Stripe; a assinatura é gerenciada em Cobrança.",
     ],
     button: "Abrir cobrança",
@@ -134,7 +134,7 @@ export const ptBR = {
   "billing.plan_changed": {
     subject: "{team} mudou de {old} para {new}",
     body: [
-      "A partir de agora {team} envia até {cap} e-mails por dia. Num limite menor, os envios já aceitos não mudam; o que passar do novo limite espera o próximo dia UTC.",
+      "A partir de agora {team} envia {cap}. Num limite menor, os envios já aceitos não mudam; o que passar do novo limite espera o próximo dia UTC.",
       "O rateio aparece na próxima fatura da Stripe.",
     ],
     button: "Abrir cobrança",
@@ -151,7 +151,7 @@ export const ptBR = {
     subject: "O plano {plan} de {team} termina em 3 dias",
     body: [
       "Em {date} {team} volta ao Free: {freeCap} e-mails por dia, e o que passar do limite espera o dia seguinte.",
-      "Retome o plano em Cobrança para manter {cap}.",
+      "Retome o plano em Cobrança para continuar enviando {cap}.",
     ],
     button: "Abrir cobrança",
   },
@@ -164,3 +164,8 @@ export const ptBR = {
     button: "Abrir cobrança",
   },
 } as const satisfies Record<AccountMailKind, AccountMailEntry>;
+
+export const ptBRPhrases = {
+  capUpTo: "até {n} e-mails por dia",
+  capNone: "sem limite diário",
+} as const satisfies Record<MailPhraseKey, string>;

--- a/packages/core/src/account-mail/pt-BR.ts
+++ b/packages/core/src/account-mail/pt-BR.ts
@@ -82,7 +82,7 @@ export const ptBR = {
   "domain.lost.identity": {
     subject: "{domain} perdeu a verificação",
     body: [
-      "A identidade SES de {domain} não existe mais, então os envios são recusados. Adicione o domínio de novo para voltar a enviar.",
+      "O SES desistiu de {domain}: a identidade sumiu ou os registros DKIM ficaram ausentes além da janela de 72 horas. Os envios são recusados; adicione o domínio de novo para voltar a enviar.",
     ],
     button: "Abrir domínios",
   },

--- a/packages/core/src/html.ts
+++ b/packages/core/src/html.ts
@@ -31,3 +31,53 @@ export function unescapeHtml(value: string): string {
  * that recipients' mail clients cannot fetch from.
  */
 export const EMAIL_WORDMARK_URL = "https://millionsend.com/email/wordmark.png";
+
+/**
+ * Fills `{key}` placeholders. A replacer function, not a replacement string:
+ * user-controlled values such as names may contain `$'` / `$$`, which
+ * String.replace would otherwise interpret. Every occurrence is filled.
+ */
+export function fillTemplate(template: string, values: Record<string, string>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key: string) => values[key] ?? match);
+}
+
+const MUTED = 'style="font-size:13px;line-height:1.5;color:#52525b;margin:24px 0 0"';
+
+/**
+ * The one account-mail layout, for every email the instance sends about
+ * itself: wordmark, white card, paragraphs, a button, then muted footers.
+ * `linkFallback` adds the button's URL as text under it, for the mails whose
+ * link is the point (a reset, a verification); without it the text version
+ * names the button instead. Everything is escaped here, so catalogs stay
+ * plain text.
+ */
+export function accountMailCard(input: {
+  paragraphs: string[];
+  button: string;
+  url: string;
+  linkFallback?: string;
+  muted: string[];
+}): { html: string; text: string } {
+  const url = escapeHtml(input.url);
+  const paragraphs = input.paragraphs
+    .map(
+      (p) =>
+        `<p style="font-size:14px;line-height:1.5;color:#18181b;margin:0 0 12px">${escapeHtml(p)}</p>`,
+    )
+    .join("\n    ");
+  const fallback = input.linkFallback
+    ? `\n    <p ${MUTED}>${escapeHtml(input.linkFallback)}<br><a href="${url}" style="color:#18181b;word-break:break-all">${url}</a></p>`
+    : "";
+  const muted = input.muted.map((m) => `<p ${MUTED}>${escapeHtml(m)}</p>`).join("\n    ");
+  const html = `<div style="background:#f4f4f5;padding:32px 16px;font-family:-apple-system,'Segoe UI',Roboto,sans-serif">
+  <div style="max-width:440px;margin:0 auto;background:#ffffff;border-radius:12px;padding:32px">
+    <img src="${EMAIL_WORDMARK_URL}" width="174" height="24" alt="MillionSend" style="display:block;height:24px;width:auto;margin:0 0 24px;border:0">
+    ${paragraphs}
+    <a href="${url}" style="display:inline-block;background:#18181b;color:#ffffff;font-size:14px;font-weight:600;text-decoration:none;border-radius:8px;padding:12px 20px;margin-top:12px">${escapeHtml(input.button)}</a>${fallback}
+    ${muted}
+  </div>
+</div>`;
+  const link = input.linkFallback ? input.url : `${input.button}: ${input.url}`;
+  const text = `${input.paragraphs.join("\n\n")}\n\n${link}\n\n${input.muted.join("\n\n")}\n`;
+  return { html, text };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export {
   accountMailPhrase,
   buildAccountMail,
   formatMailDate,
+  formatMailDateTime,
   isMailLocale,
   MAIL_LOCALES,
   type MailContent,
@@ -201,6 +202,7 @@ export {
   rewriteForTracking,
 } from "./link-tracking.js";
 export {
+  accountLocale,
   claimNotification,
   clearNotifications,
   listTeamOwners,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,10 +22,14 @@ export {
   type AccountMailKind,
   accountMailPhrase,
   buildAccountMail,
+  formatMailDate,
   isMailLocale,
   MAIL_LOCALES,
   type MailContent,
   type MailLocale,
+  type MailPhraseKey,
+  PLAN_NAME,
+  planCapPhrase,
 } from "./account-mail.js";
 export {
   ACCOUNT_SCORE_WINDOW_DAYS,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,17 @@ export {
   verifySenderDomain,
 } from "./accept-email.js";
 export {
+  ACCOUNT_MAIL_KINDS,
+  type AccountMailEntry,
+  type AccountMailKind,
+  accountMailPhrase,
+  buildAccountMail,
+  isMailLocale,
+  MAIL_LOCALES,
+  type MailContent,
+  type MailLocale,
+} from "./account-mail.js";
+export {
   ACCOUNT_SCORE_WINDOW_DAYS,
   type AccountScore,
   type AccountScoreInput,
@@ -169,7 +180,7 @@ export {
 export { purgedEmailBodyColumns } from "./email-retention.js";
 export { ERASED_TOMBSTONE, type EraseRecipientResult, eraseRecipient } from "./erase-recipient.js";
 export { type SesEventsHealth, sesEventsHealth } from "./events-health.js";
-export { EMAIL_WORDMARK_URL, escapeHtml } from "./html.js";
+export { accountMailCard, EMAIL_WORDMARK_URL, escapeHtml, fillTemplate } from "./html.js";
 export {
   beginIdempotent,
   completeIdempotent,
@@ -185,7 +196,12 @@ export {
   type RewriteOptions,
   rewriteForTracking,
 } from "./link-tracking.js";
-export { claimNotification, clearNotifications, listTeamOwners } from "./notifications.js";
+export {
+  claimNotification,
+  clearNotifications,
+  listTeamOwners,
+  type TeamOwner,
+} from "./notifications.js";
 export {
   ADMIN_MCP_SCOPES,
   ALL_TEAMS_GRANT,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export {
   type AccountMailKind,
   accountMailPhrase,
   buildAccountMail,
+  CANCEL_REMINDER_DAYS,
   formatMailDate,
   formatMailDateTime,
   isMailLocale,
@@ -30,7 +31,10 @@ export {
   type MailLocale,
   type MailPhraseKey,
   PLAN_NAME,
+  type PlanMove,
+  type PlanSnapshot,
   planCapPhrase,
+  planMove,
 } from "./account-mail.js";
 export {
   ACCOUNT_SCORE_WINDOW_DAYS,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,6 +206,13 @@ export {
   rewriteForTracking,
 } from "./link-tracking.js";
 export {
+  isMailPreferenceKey,
+  MAIL_PREFERENCE_GROUPS,
+  MAIL_PREFERENCE_KEYS,
+  type MailPreferenceKey,
+  mailPreferenceOf,
+} from "./mail-preferences.js";
+export {
   accountLocale,
   claimNotification,
   clearNotifications,

--- a/packages/core/src/mail-preferences.ts
+++ b/packages/core/src/mail-preferences.ts
@@ -1,0 +1,55 @@
+// Pure list, safe to import from client components (no db or node imports).
+import type { SystemMailKind } from "./system-mail.js";
+
+/**
+ * The owner notices a person may turn off, grouped as the settings page
+ * shows them. A key covers every kind it stands for: the severity steps of
+ * one notice fold into one switch, as does a domain's two ways of losing
+ * verification. Mail about the account itself (welcome, password, apps) and
+ * the security receipts (keys, webhook secrets) are not here: always sent.
+ */
+export const MAIL_PREFERENCE_GROUPS = [
+  { group: "domains", cloudOnly: false, keys: ["domain.verified", "domain.lost"] },
+  { group: "team", cloudOnly: false, keys: ["member.joined"] },
+  {
+    group: "broadcasts",
+    cloudOnly: false,
+    keys: ["broadcast.sent", "broadcast.held_quota", "broadcast.held"],
+  },
+  { group: "sending", cloudOnly: false, keys: ["quota", "deliverability"] },
+  {
+    group: "webhooks",
+    cloudOnly: false,
+    keys: ["webhook.failing", "webhook.auto_disabled", "webhook.backlog"],
+  },
+  {
+    group: "billing",
+    cloudOnly: true,
+    keys: [
+      "billing.payment_failed",
+      "billing.plan_activated",
+      "billing.plan_changed",
+      "billing.cancel_scheduled",
+      "billing.cancel_reminder",
+      "billing.downgraded",
+    ],
+  },
+] as const;
+
+export type MailPreferenceKey = (typeof MAIL_PREFERENCE_GROUPS)[number]["keys"][number];
+
+export const MAIL_PREFERENCE_KEYS: readonly MailPreferenceKey[] = MAIL_PREFERENCE_GROUPS.flatMap(
+  (g) => g.keys,
+);
+
+export function isMailPreferenceKey(value: unknown): value is MailPreferenceKey {
+  return typeof value === "string" && (MAIL_PREFERENCE_KEYS as readonly string[]).includes(value);
+}
+
+/** The switch a kind answers to; null for mail that is always sent. */
+export function mailPreferenceOf(kind: SystemMailKind): MailPreferenceKey | null {
+  if (kind === "domain.lost.identity") return "domain.lost";
+  if (kind.startsWith("quota.")) return "quota";
+  if (kind.startsWith("deliverability.")) return "deliverability";
+  return isMailPreferenceKey(kind) ? kind : null;
+}

--- a/packages/core/src/notifications.ts
+++ b/packages/core/src/notifications.ts
@@ -1,6 +1,8 @@
 import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
+import { isMailLocale, type MailLocale } from "./account-mail.js";
+import { findSenderDomainOwner } from "./system-mail.js";
 
 /**
  * Claim the right to send one notification for (team, kind, period). True for
@@ -34,14 +36,44 @@ export async function clearNotifications(
     );
 }
 
-/** The addresses account notifications go to. */
+export interface TeamOwner {
+  email: string;
+  name: string;
+  /** The language to write to them in. */
+  locale: MailLocale;
+}
+
+/**
+ * The addresses account notifications go to. With the account-mail sender
+ * given, each owner's language is read off their contact in the team that
+ * holds that sender's domain — the row sign-up enrolls, whose `locale`
+ * property is the one language the instance knows for a person outside a
+ * request. Owners without one, or an instance where no team holds the
+ * sender, read English.
+ */
 export async function listTeamOwners(
   db: Db,
   teamId: string,
-): Promise<{ email: string; name: string }[]> {
-  return db
-    .select({ email: schema.user.email, name: schema.user.name })
+  accountMailFrom?: string | null,
+): Promise<TeamOwner[]> {
+  const home = accountMailFrom ? await findSenderDomainOwner(db, accountMailFrom) : null;
+  const c = schema.contacts;
+  const rows = await db
+    .select({
+      email: schema.user.email,
+      name: schema.user.name,
+      locale: home
+        ? sql<
+            string | null
+          >`(select ${c.properties}->>'locale' from ${c} where ${c.teamId} = ${home.teamId} and lower(${c.email}) = lower(${schema.user.email}) limit 1)`
+        : sql<string | null>`null`,
+    })
     .from(schema.teamMembers)
     .innerJoin(schema.user, eq(schema.user.id, schema.teamMembers.userId))
     .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.role, "owner")));
+  return rows.map((row) => ({
+    email: row.email,
+    name: row.name,
+    locale: isMailLocale(row.locale) ? row.locale : "en",
+  }));
 }

--- a/packages/core/src/notifications.ts
+++ b/packages/core/src/notifications.ts
@@ -77,3 +77,20 @@ export async function listTeamOwners(
     locale: isMailLocale(row.locale) ? row.locale : "en",
   }));
 }
+
+/** The language the instance knows for one address, read the same way; English when it knows none. */
+export async function accountLocale(
+  db: Db,
+  accountMailFrom: string | null | undefined,
+  email: string,
+): Promise<MailLocale> {
+  const home = accountMailFrom ? await findSenderDomainOwner(db, accountMailFrom) : null;
+  if (!home) return "en";
+  const c = schema.contacts;
+  const [row] = await db
+    .select({ locale: sql<string | null>`${c.properties}->>'locale'` })
+    .from(c)
+    .where(and(eq(c.teamId, home.teamId), sql`lower(${c.email}) = lower(${email})`))
+    .limit(1);
+  return isMailLocale(row?.locale) ? row.locale : "en";
+}

--- a/packages/core/src/notifications.ts
+++ b/packages/core/src/notifications.ts
@@ -2,7 +2,8 @@ import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
 import { and, eq, sql } from "drizzle-orm";
 import { isMailLocale, type MailLocale } from "./account-mail.js";
-import { findSenderDomainOwner } from "./system-mail.js";
+import { mailPreferenceOf } from "./mail-preferences.js";
+import { findSenderDomainOwner, type SystemMailKind } from "./system-mail.js";
 
 /**
  * Claim the right to send one notification for (team, kind, period). True for
@@ -49,14 +50,17 @@ export interface TeamOwner {
  * holds that sender's domain — the row sign-up enrolls, whose `locale`
  * property is the one language the instance knows for a person outside a
  * request. Owners without one, or an instance where no team holds the
- * sender, read English.
+ * sender, read English. With the kind given, an owner who turned that
+ * notice off is left out; mail that is always sent names no switch.
  */
 export async function listTeamOwners(
   db: Db,
   teamId: string,
   accountMailFrom?: string | null,
+  kind?: SystemMailKind,
 ): Promise<TeamOwner[]> {
   const home = accountMailFrom ? await findSenderDomainOwner(db, accountMailFrom) : null;
+  const preference = kind ? mailPreferenceOf(kind) : null;
   const c = schema.contacts;
   const rows = await db
     .select({
@@ -70,7 +74,13 @@ export async function listTeamOwners(
     })
     .from(schema.teamMembers)
     .innerJoin(schema.user, eq(schema.user.id, schema.teamMembers.userId))
-    .where(and(eq(schema.teamMembers.teamId, teamId), eq(schema.teamMembers.role, "owner")));
+    .where(
+      and(
+        eq(schema.teamMembers.teamId, teamId),
+        eq(schema.teamMembers.role, "owner"),
+        preference ? sql`not (${schema.user.mailOptOuts} ? ${preference})` : undefined,
+      ),
+    );
   return rows.map((row) => ({
     email: row.email,
     name: row.name,

--- a/packages/core/src/system-mail.ts
+++ b/packages/core/src/system-mail.ts
@@ -2,6 +2,7 @@ import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
 import { and, asc, eq, sql } from "drizzle-orm";
 import { type AcceptEmailDeps, acceptEmail } from "./accept-email.js";
+import type { AccountMailKind } from "./account-mail.js";
 import { parseSingleSender } from "./sender-address.js";
 
 /**
@@ -26,7 +27,8 @@ export type SystemMailKind =
   | "webhook.failing"
   | "webhook.auto_disabled"
   | "webhook.backlog"
-  | "updates.confirm";
+  | "updates.confirm"
+  | AccountMailKind;
 
 export interface SystemMailMessage {
   /** `Name <user@domain>` or a bare address; one of the instance's sender env vars. */

--- a/packages/core/test/account-mail.test.ts
+++ b/packages/core/test/account-mail.test.ts
@@ -1,6 +1,7 @@
+import type { Db } from "@millionsend/db";
 import { schema } from "@millionsend/db";
 import { createTeam, createTestDb } from "@millionsend/test-utils";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { en } from "../src/account-mail/en.js";
 import { ptBR } from "../src/account-mail/pt-BR.js";
 import {
@@ -133,44 +134,47 @@ describe("accountMailCard", () => {
 });
 
 describe("listTeamOwners", () => {
+  // The PGlite boot belongs in the hook: it has the long timeout, the test does not.
+  let db: Db;
+  let close: () => Promise<void>;
+  beforeAll(async () => {
+    ({ db, close } = await createTestDb());
+  });
+  afterAll(() => close());
+
   it("reads each owner's language off their contact in the account-mail team, English otherwise", async () => {
-    const { db, close } = await createTestDb();
-    try {
-      const teamId = await createTeam(db, "acme");
-      const home = await createTeam(db, "home");
-      await db.insert(schema.domains).values({
-        teamId: home,
-        name: "mail.example.com",
-        region: "us-east-1",
-        status: "verified",
-      });
-      await db.insert(schema.user).values([
-        { id: "u1", name: "Ana", email: "Ana@example.com" },
-        { id: "u2", name: "Bob", email: "bob@example.com" },
-        { id: "u3", name: "Cid", email: "cid@example.com" },
-      ]);
-      await db.insert(schema.teamMembers).values([
-        { teamId, userId: "u1", role: "owner" },
-        { teamId, userId: "u2", role: "owner" },
-        { teamId, userId: "u3", role: "member" },
-      ]);
-      await db.insert(schema.contacts).values([
-        { teamId: home, email: "ana@example.com", properties: { locale: "pt-BR" } },
-        { teamId: home, email: "bob@example.com", properties: { locale: "xx" } },
-      ]);
-      const owners = await listTeamOwners(db, teamId, "MillionSend <account@mail.example.com>");
-      expect(owners.map((o) => [o.email, o.locale]).sort()).toEqual([
-        ["Ana@example.com", "pt-BR"],
-        ["bob@example.com", "en"],
-      ]);
-      // No sender, or a sender no team holds: nothing to read, English.
-      expect((await listTeamOwners(db, teamId)).map((o) => o.locale)).toEqual(["en", "en"]);
-      expect(
-        (await listTeamOwners(db, teamId, "x@nobody.example.com")).map((o) => o.locale),
-      ).toEqual(["en", "en"]);
-    } finally {
-      await close();
-    }
+    const teamId = await createTeam(db, "acme");
+    const home = await createTeam(db, "home");
+    await db.insert(schema.domains).values({
+      teamId: home,
+      name: "mail.example.com",
+      region: "us-east-1",
+      status: "verified",
+    });
+    await db.insert(schema.user).values([
+      { id: "u1", name: "Ana", email: "Ana@example.com" },
+      { id: "u2", name: "Bob", email: "bob@example.com" },
+      { id: "u3", name: "Cid", email: "cid@example.com" },
+    ]);
+    await db.insert(schema.teamMembers).values([
+      { teamId, userId: "u1", role: "owner" },
+      { teamId, userId: "u2", role: "owner" },
+      { teamId, userId: "u3", role: "member" },
+    ]);
+    await db.insert(schema.contacts).values([
+      { teamId: home, email: "ana@example.com", properties: { locale: "pt-BR" } },
+      { teamId: home, email: "bob@example.com", properties: { locale: "xx" } },
+    ]);
+    const owners = await listTeamOwners(db, teamId, "MillionSend <account@mail.example.com>");
+    expect(owners.map((o) => [o.email, o.locale]).sort()).toEqual([
+      ["Ana@example.com", "pt-BR"],
+      ["bob@example.com", "en"],
+    ]);
+    // No sender, or a sender no team holds: nothing to read, English.
+    expect((await listTeamOwners(db, teamId)).map((o) => o.locale)).toEqual(["en", "en"]);
+    expect((await listTeamOwners(db, teamId, "x@nobody.example.com")).map((o) => o.locale)).toEqual(
+      ["en", "en"],
+    );
   });
 });
 

--- a/packages/core/test/account-mail.test.ts
+++ b/packages/core/test/account-mail.test.ts
@@ -5,9 +5,12 @@ import { en } from "../src/account-mail/en.js";
 import { ptBR } from "../src/account-mail/pt-BR.js";
 import {
   ACCOUNT_MAIL_KINDS,
+  type AccountMailEntry,
   accountMailPhrase,
   buildAccountMail,
+  formatMailDate,
   MAIL_LOCALES,
+  planCapPhrase,
 } from "../src/account-mail.js";
 import { accountMailCard } from "../src/html.js";
 import { listTeamOwners } from "../src/notifications.js";
@@ -68,8 +71,8 @@ describe("account mail catalogs", () => {
   it("carries the same slots in pt-BR as in en, entry by entry", () => {
     const slots = (s: string) => [...s.matchAll(/\{\w+\}/g)].map((m) => m[0]).sort();
     for (const kind of ACCOUNT_MAIL_KINDS) {
-      const a = en[kind];
-      const b = ptBR[kind];
+      const a: AccountMailEntry = en[kind];
+      const b: AccountMailEntry = ptBR[kind];
       expect(slots(b.subject), `${kind} subject`).toEqual(slots(a.subject));
       expect(slots(b.body.join(" ")), `${kind} body`).toEqual(slots(a.body.join(" ")));
       expect(Object.keys(b.extra ?? {}).sort(), `${kind} extra`).toEqual(
@@ -166,5 +169,17 @@ describe("listTeamOwners", () => {
     } finally {
       await close();
     }
+  });
+});
+
+describe("billing phrases", () => {
+  it("say a plan's cap as a clause and a date on its UTC day, each in the reader's language", () => {
+    expect(planCapPhrase("en", "pro")).toBe("up to 3,000 emails a day");
+    expect(planCapPhrase("pt-BR", "pro")).toBe("até 3.000 e-mails por dia");
+    expect(planCapPhrase("en", "scale")).toBe("with no daily cap");
+    expect(planCapPhrase("pt-BR", "scale")).toBe("sem limite diário");
+    const lateUtc = new Date("2026-09-30T23:30:00Z");
+    expect(formatMailDate("en", lateUtc)).toBe("September 30, 2026");
+    expect(formatMailDate("pt-BR", lateUtc)).toBe("30 de setembro de 2026");
   });
 });

--- a/packages/core/test/account-mail.test.ts
+++ b/packages/core/test/account-mail.test.ts
@@ -15,7 +15,9 @@ import {
   planMove,
 } from "../src/account-mail.js";
 import { accountMailCard } from "../src/html.js";
+import { mailPreferenceOf } from "../src/mail-preferences.js";
 import { listTeamOwners } from "../src/notifications.js";
+import type { SystemMailKind } from "../src/system-mail.js";
 
 const VALUES: Record<string, string> = Object.fromEntries(
   [
@@ -176,6 +178,25 @@ describe("listTeamOwners", () => {
       ["en", "en"],
     );
   });
+
+  it("leaves out an owner who turned a notice off, never for mail that is always sent", async () => {
+    const teamId = await createTeam(db, "quiet");
+    await db.insert(schema.user).values({
+      id: "q1",
+      name: "Q",
+      email: "q@example.com",
+      mailOptOuts: ["broadcast.sent", "quota", "domain.lost"],
+    });
+    await db.insert(schema.teamMembers).values({ teamId, userId: "q1", role: "owner" });
+    const emails = async (kind?: SystemMailKind) =>
+      (await listTeamOwners(db, teamId, undefined, kind)).map((o) => o.email);
+    expect(await emails()).toEqual(["q@example.com"]);
+    expect(await emails("broadcast.sent")).toEqual([]);
+    expect(await emails("quota.paused")).toEqual([]);
+    expect(await emails("domain.lost.identity")).toEqual([]);
+    expect(await emails("broadcast.held")).toEqual(["q@example.com"]);
+    expect(await emails("api_key.created")).toEqual(["q@example.com"]);
+  });
 });
 
 describe("billing phrases", () => {
@@ -248,5 +269,24 @@ describe("planMove", () => {
       date: "30 de agosto de 2026",
       freeCap: "100",
     });
+  });
+});
+
+describe("mailPreferenceOf", () => {
+  it("folds severity steps and the identity variant into one switch, and names none for mail that is always sent", () => {
+    expect(mailPreferenceOf("quota.warning")).toBe("quota");
+    expect(mailPreferenceOf("deliverability.paused")).toBe("deliverability");
+    expect(mailPreferenceOf("domain.lost.identity")).toBe("domain.lost");
+    expect(mailPreferenceOf("billing.downgraded")).toBe("billing.downgraded");
+    const always = [
+      "welcome",
+      "password_changed",
+      "mcp.connected",
+      "api_key.created",
+      "webhook.secret_rotated",
+      "password_reset",
+      "region.paused",
+    ] as const;
+    for (const kind of always) expect(mailPreferenceOf(kind), kind).toBeNull();
   });
 });

--- a/packages/core/test/account-mail.test.ts
+++ b/packages/core/test/account-mail.test.ts
@@ -11,6 +11,7 @@ import {
   formatMailDate,
   MAIL_LOCALES,
   planCapPhrase,
+  planMove,
 } from "../src/account-mail.js";
 import { accountMailCard } from "../src/html.js";
 import { listTeamOwners } from "../src/notifications.js";
@@ -30,6 +31,7 @@ const VALUES: Record<string, string> = Object.fromEntries(
     "url",
     "host",
     "until",
+    "deadline",
     "role",
     "domain",
     "subject",
@@ -181,5 +183,66 @@ describe("billing phrases", () => {
     const lateUtc = new Date("2026-09-30T23:30:00Z");
     expect(formatMailDate("en", lateUtc)).toBe("September 30, 2026");
     expect(formatMailDate("pt-BR", lateUtc)).toBe("30 de setembro de 2026");
+  });
+});
+
+describe("planMove", () => {
+  const now = new Date("2026-09-08T12:00:00Z");
+  const row = (
+    plan: "free" | "pro" | "scale",
+    periodEnd: string | null,
+    cancelAt: string | null = null,
+  ) => ({
+    plan,
+    currentPeriodEnd: periodEnd ? new Date(periodEnd) : null,
+    cancelAt: cancelAt ? new Date(cancelAt) : null,
+  });
+
+  it("keys an activation and a change by the period the new plan starts, and a downgrade by the period that ended", () => {
+    const up = planMove(row("free", null), row("pro", "2026-10-08T00:00:00Z"), now);
+    expect(up?.kind).toBe("billing.plan_activated");
+    expect(up?.periodKey).toBe("pro:2026-10-08T00:00:00.000Z");
+    expect(up?.values("en", "Acme")).toEqual({
+      team: "Acme",
+      plan: "Pro",
+      cap: "up to 3,000 emails a day",
+    });
+    const moved = planMove(
+      row("pro", "2026-10-08T00:00:00Z"),
+      row("scale", "2026-10-08T00:00:00Z"),
+      now,
+    );
+    expect(moved?.kind).toBe("billing.plan_changed");
+    expect(moved?.periodKey).toBe("pro>scale:2026-10-08T00:00:00.000Z");
+    expect(moved?.values("pt-BR", "Acme")).toMatchObject({
+      old: "Pro",
+      new: "Scale",
+      cap: "sem limite diário",
+    });
+    const down = planMove(row("pro", "2026-09-30T00:00:00Z"), row("free", null), now);
+    expect(down?.kind).toBe("billing.downgraded");
+    expect(down?.periodKey).toBe("2026-09-30T00:00:00.000Z");
+    expect(planMove(row("pro", null), row("pro", null), now)).toBeNull();
+  });
+
+  it("dates a downgrade at the earliest of the scheduled cancel, the period end and today", () => {
+    const immediate = planMove(row("pro", "2026-09-30T00:00:00Z"), row("free", null), now);
+    expect(immediate?.values("en", "Acme").date).toBe("September 8, 2026");
+    const scheduled = planMove(
+      row("pro", "2026-09-30T00:00:00Z", "2026-09-01T00:00:00Z"),
+      row("free", null),
+      now,
+    );
+    expect(scheduled?.values("en", "Acme").date).toBe("September 1, 2026");
+    const lapsed = planMove(
+      row("scale", "2026-08-30T00:00:00Z"),
+      row("free", "2026-08-30T00:00:00Z"),
+      now,
+    );
+    expect(lapsed?.values("pt-BR", "Acme")).toMatchObject({
+      plan: "Scale",
+      date: "30 de agosto de 2026",
+      freeCap: "100",
+    });
   });
 });

--- a/packages/core/test/account-mail.test.ts
+++ b/packages/core/test/account-mail.test.ts
@@ -1,0 +1,170 @@
+import { schema } from "@millionsend/db";
+import { createTeam, createTestDb } from "@millionsend/test-utils";
+import { describe, expect, it } from "vitest";
+import { en } from "../src/account-mail/en.js";
+import { ptBR } from "../src/account-mail/pt-BR.js";
+import {
+  ACCOUNT_MAIL_KINDS,
+  accountMailPhrase,
+  buildAccountMail,
+  MAIL_LOCALES,
+} from "../src/account-mail.js";
+import { accountMailCard } from "../src/html.js";
+import { listTeamOwners } from "../src/notifications.js";
+
+const VALUES: Record<string, string> = Object.fromEntries(
+  [
+    "name",
+    "email",
+    "app",
+    "team",
+    "scopes",
+    "actor",
+    "prefix",
+    "last4",
+    "permission",
+    "scope",
+    "url",
+    "host",
+    "until",
+    "role",
+    "domain",
+    "subject",
+    "count",
+    "parked",
+    "sent",
+    "limit",
+    "resetsAt",
+    "region",
+    "plan",
+    "retry",
+    "cap",
+    "freeCap",
+    "billingUrl",
+    "old",
+    "new",
+    "date",
+    "docsUrl",
+  ].map((key) => [key, `[${key}]`]),
+);
+
+describe("account mail catalogs", () => {
+  it("render every kind in every language with no placeholder left", () => {
+    for (const locale of MAIL_LOCALES) {
+      for (const kind of ACCOUNT_MAIL_KINDS) {
+        const mail = buildAccountMail({
+          kind,
+          locale,
+          url: "https://app.example/x",
+          values: VALUES,
+        });
+        expect(mail.subject, `${locale} ${kind}`).not.toMatch(/\{\w+\}/);
+        expect(mail.text, `${locale} ${kind}`).not.toMatch(/\{\w+\}/);
+        expect(mail.html, `${locale} ${kind}`).toContain("https://app.example/x");
+      }
+    }
+  });
+
+  it("carries the same slots in pt-BR as in en, entry by entry", () => {
+    const slots = (s: string) => [...s.matchAll(/\{\w+\}/g)].map((m) => m[0]).sort();
+    for (const kind of ACCOUNT_MAIL_KINDS) {
+      const a = en[kind];
+      const b = ptBR[kind];
+      expect(slots(b.subject), `${kind} subject`).toEqual(slots(a.subject));
+      expect(slots(b.body.join(" ")), `${kind} body`).toEqual(slots(a.body.join(" ")));
+      expect(Object.keys(b.extra ?? {}).sort(), `${kind} extra`).toEqual(
+        Object.keys(a.extra ?? {}).sort(),
+      );
+    }
+  });
+
+  it("escapes what the values carry", () => {
+    const mail = buildAccountMail({
+      kind: "member.joined",
+      locale: "en",
+      url: "https://app.example/settings",
+      values: { ...VALUES, team: "<b>Acme</b>" },
+    });
+    expect(mail.html).toContain("&lt;b&gt;Acme&lt;/b&gt;");
+    expect(mail.html).not.toContain("<b>Acme</b>");
+    expect(mail.text).toContain("<b>Acme</b>");
+  });
+
+  it("fills a phrase from an entry's extras", () => {
+    expect(
+      accountMailPhrase({
+        locale: "pt-BR",
+        kind: "billing.payment_failed",
+        key: "retryOn",
+        values: { date: "1 de outubro" },
+      }),
+    ).toBe("A Stripe tenta de novo em 1 de outubro.");
+  });
+});
+
+describe("accountMailCard", () => {
+  it("names the button in the text version when there is no link fallback", () => {
+    const card = accountMailCard({
+      paragraphs: ["Hello"],
+      button: "Open",
+      url: "https://app.example/x",
+      muted: ["Bye"],
+    });
+    expect(card.text).toBe("Hello\n\nOpen: https://app.example/x\n\nBye\n");
+    expect(card.html).not.toContain("word-break:break-all");
+  });
+
+  it("prints the bare link when a fallback line is given", () => {
+    const card = accountMailCard({
+      paragraphs: ["Hello"],
+      button: "Open",
+      url: "https://app.example/x",
+      linkFallback: "Or paste this:",
+      muted: [],
+    });
+    expect(card.text).toBe("Hello\n\nhttps://app.example/x\n\n\n");
+    expect(card.html).toContain("Or paste this:<br>");
+  });
+});
+
+describe("listTeamOwners", () => {
+  it("reads each owner's language off their contact in the account-mail team, English otherwise", async () => {
+    const { db, close } = await createTestDb();
+    try {
+      const teamId = await createTeam(db, "acme");
+      const home = await createTeam(db, "home");
+      await db.insert(schema.domains).values({
+        teamId: home,
+        name: "mail.example.com",
+        region: "us-east-1",
+        status: "verified",
+      });
+      await db.insert(schema.user).values([
+        { id: "u1", name: "Ana", email: "Ana@example.com" },
+        { id: "u2", name: "Bob", email: "bob@example.com" },
+        { id: "u3", name: "Cid", email: "cid@example.com" },
+      ]);
+      await db.insert(schema.teamMembers).values([
+        { teamId, userId: "u1", role: "owner" },
+        { teamId, userId: "u2", role: "owner" },
+        { teamId, userId: "u3", role: "member" },
+      ]);
+      await db.insert(schema.contacts).values([
+        { teamId: home, email: "ana@example.com", properties: { locale: "pt-BR" } },
+        { teamId: home, email: "bob@example.com", properties: { locale: "xx" } },
+      ]);
+      const owners = await listTeamOwners(db, teamId, "MillionSend <account@mail.example.com>");
+      expect(owners.map((o) => [o.email, o.locale]).sort()).toEqual([
+        ["Ana@example.com", "pt-BR"],
+        ["bob@example.com", "en"],
+      ]);
+      // No sender, or a sender no team holds: nothing to read, English.
+      expect((await listTeamOwners(db, teamId)).map((o) => o.locale)).toEqual(["en", "en"]);
+      expect(
+        (await listTeamOwners(db, teamId, "x@nobody.example.com")).map((o) => o.locale),
+      ).toEqual(["en", "en"]);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/packages/db/drizzle/0033_account_emails.sql
+++ b/packages/db/drizzle/0033_account_emails.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "teams" ADD COLUMN "cancel_at" timestamp with time zone;--> statement-breakpoint
+-- IF NOT EXISTS: an operator may build it CONCURRENTLY under the same name before deploying.
+CREATE INDEX IF NOT EXISTS "audit_log_action_recent_idx" ON "audit_log" USING btree ("action","created_at");--> statement-breakpoint
+-- Domains already verified must not be greeted as newly verified on the first sweep.
+INSERT INTO "team_notifications" ("team_id", "kind", "period_key")
+SELECT "team_id", 'domain.verified:' || "id", 'episode' FROM "domains" WHERE "status" = 'verified'
+ON CONFLICT DO NOTHING;--> statement-breakpoint
+-- Credential events from before this deploy were never owed a notice.
+INSERT INTO "team_notifications" ("team_id", "kind", "period_key")
+SELECT "team_id", "action", "id"::text FROM "audit_log"
+WHERE "action" IN ('api_key.created', 'webhook.secret_rotated', 'member.joined')
+  AND "created_at" > now() - interval '24 hours'
+  AND "team_id" IN (SELECT "id" FROM "teams")
+ON CONFLICT DO NOTHING;

--- a/packages/db/drizzle/0034_mail_opt_outs.sql
+++ b/packages/db/drizzle/0034_mail_opt_outs.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "mail_opt_outs" jsonb DEFAULT '[]'::jsonb NOT NULL;

--- a/packages/db/drizzle/meta/0033_snapshot.json
+++ b/packages/db/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,5551 @@
+{
+  "id": "5548d277-49b3-4b9b-8f78-9f0f1db9f1ec",
+  "prevId": "7a92be83-2bef-4875-b22c-8b897e9ca674",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "api_key_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_access'"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_api_key_id": {
+          "name": "created_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_token_prefix_idx": {
+          "name": "api_keys_token_prefix_idx",
+          "columns": [
+            {
+              "expression": "token_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_team_id_teams_id_fk": {
+          "name": "api_keys_team_id_teams_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_domain_id_domains_id_fk": {
+          "name": "api_keys_domain_id_domains_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_api_key_id_api_keys_id_fk": {
+          "name": "api_keys_created_by_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "created_by_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_rate_limits": {
+      "name": "api_rate_limits",
+      "schema": "",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_rate_limits_api_key_id_api_keys_id_fk": {
+          "name": "api_rate_limits_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_rate_limits",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_requests": {
+      "name": "api_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_bytes": {
+          "name": "request_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_bytes": {
+          "name": "response_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_requests_team_created_idx": {
+          "name": "api_requests_team_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_requests_created_idx": {
+          "name": "api_requests_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_requests_team_oauth_client_idx": {
+          "name": "api_requests_team_oauth_client_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_requests\".\"oauth_client_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_requests_team_id_teams_id_fk": {
+          "name": "api_requests_team_id_teams_id_fk",
+          "tableFrom": "api_requests",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_requests_api_key_id_api_keys_id_fk": {
+          "name": "api_requests_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_requests",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_team_idx": {
+          "name": "audit_log_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_recent_idx": {
+          "name": "audit_log_action_recent_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_issuer_account_id_idx": {
+          "name": "account_issuer_account_id_idx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_id_idx": {
+          "name": "oauth_access_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_authorization_code_id_idx": {
+          "name": "oauth_access_token_authorization_code_id_idx",
+          "columns": [
+            {
+              "expression": "authorization_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_refresh_id_idx": {
+          "name": "oauth_access_token_refresh_id_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_discovery_id": {
+          "name": "client_discovery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_credentials_scopes": {
+          "name": "client_credentials_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backchannel_logout_uri": {
+          "name": "backchannel_logout_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backchannel_logout_session_required": {
+          "name": "backchannel_logout_session_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_type": {
+          "name": "application_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks": {
+          "name": "jwks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks_uri": {
+          "name": "jwks_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpop_bound_access_tokens": {
+          "name": "dpop_bound_access_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_client_user_id_idx": {
+          "name": "oauth_client_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client_assertion": {
+      "name": "oauth_client_assertion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client_resource": {
+      "name": "oauth_client_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_client_resource_client_id_idx": {
+          "name": "oauth_client_resource_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_client_resource_resource_id_idx": {
+          "name": "oauth_client_resource_resource_id_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_resource_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_client_resource_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_client_resource",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_resource_resource_id_oauth_resource_identifier_fk": {
+          "name": "oauth_client_resource_resource_id_oauth_resource_identifier_fk",
+          "tableFrom": "oauth_client_resource",
+          "tableTo": "oauth_resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "identifier"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_reference_id_idx": {
+          "name": "oauth_consent_reference_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_replay_response": {
+          "name": "rotation_replay_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_replay_expires_at": {
+          "name": "rotation_replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_id_idx": {
+          "name": "oauth_refresh_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_id_idx": {
+          "name": "oauth_refresh_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_id_idx": {
+          "name": "oauth_refresh_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_authorization_code_id_idx": {
+          "name": "oauth_refresh_token_authorization_code_id_idx",
+          "columns": [
+            {
+              "expression": "authorization_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_resource": {
+      "name": "oauth_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ttl": {
+          "name": "access_token_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_ttl": {
+          "name": "refresh_token_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_algorithm": {
+          "name": "signing_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_claims": {
+          "name": "custom_claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpop_bound_access_tokens_required": {
+          "name": "dpop_bound_access_tokens_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_resource_identifier_unique": {
+          "name": "oauth_resource_identifier_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identifier"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_members_team_user_idx": {
+          "name": "team_members_team_user_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_user_id_fk": {
+          "name": "team_members_user_id_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcasts": {
+      "name": "broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_count": {
+          "name": "recipient_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_count": {
+          "name": "delivered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_count": {
+          "name": "bounced_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complained_count": {
+          "name": "complained_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcasts_team_idx": {
+          "name": "broadcasts_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcasts_team_id_teams_id_fk": {
+          "name": "broadcasts_team_id_teams_id_fk",
+          "tableFrom": "broadcasts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "broadcasts_topic_id_topics_id_fk": {
+          "name": "broadcasts_topic_id_topics_id_fk",
+          "tableFrom": "broadcasts",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "broadcasts_segment_id_segments_id_fk": {
+          "name": "broadcasts_segment_id_segments_id_fk",
+          "tableFrom": "broadcasts",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_activities": {
+      "name": "contact_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_activities_contact_idx": {
+          "name": "contact_activities_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_activities_team_id_teams_id_fk": {
+          "name": "contact_activities_team_id_teams_id_fk",
+          "tableFrom": "contact_activities",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_activities_contact_id_contacts_id_fk": {
+          "name": "contact_activities_contact_id_contacts_id_fk",
+          "tableFrom": "contact_activities",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_properties": {
+      "name": "contact_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "contact_property_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "fallback_value": {
+          "name": "fallback_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_properties_team_key_idx": {
+          "name": "contact_properties_team_key_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"key\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_properties_team_id_teams_id_fk": {
+          "name": "contact_properties_team_id_teams_id_fk",
+          "tableFrom": "contact_properties",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "unsubscribed": {
+          "name": "unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_team_email_idx": {
+          "name": "contacts_team_email_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_team_created_idx": {
+          "name": "contacts_team_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_team_id_idx": {
+          "name": "contacts_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_team_updated_idx": {
+          "name": "contacts_team_updated_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_team_id_teams_id_fk": {
+          "name": "contacts_team_id_teams_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dkim_selector": {
+          "name": "dkim_selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_public_key": {
+          "name": "dkim_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_from_subdomain": {
+          "name": "mail_from_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'send'"
+        },
+        "tracking_subdomain": {
+          "name": "tracking_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_subdomain_set_at": {
+          "name": "tracking_subdomain_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_tracking": {
+          "name": "click_tracking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "open_tracking": {
+          "name": "open_tracking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls_mode": {
+          "name": "tls_mode",
+          "type": "tls_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opportunistic'"
+        },
+        "ses_configuration_set": {
+          "name": "ses_configuration_set",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_tenant_associated_at": {
+          "name": "ses_tenant_associated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_tenant_config_set": {
+          "name": "ses_tenant_config_set",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_records": {
+          "name": "dns_records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dmarc_policy": {
+          "name": "dmarc_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dmarc_checked_at": {
+          "name": "dmarc_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "domains_team_name_idx": {
+          "name": "domains_team_name_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_team_id_teams_id_fk": {
+          "name": "domains_team_id_teams_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_insights": {
+      "name": "email_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checks": {
+          "name": "checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_tenths": {
+          "name": "score_tenths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_version": {
+          "name": "score_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_size_bytes": {
+          "name": "html_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_size_bytes": {
+          "name": "mime_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_insights_team_id_teams_id_fk": {
+          "name": "email_insights_team_id_teams_id_fk",
+          "tableFrom": "email_insights",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_insights_email_id_emails_id_fk": {
+          "name": "email_insights_email_id_emails_id_fk",
+          "tableFrom": "email_insights",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_insights_broadcast_id_broadcasts_id_fk": {
+          "name": "email_insights_broadcast_id_broadcasts_id_fk",
+          "tableFrom": "email_insights",
+          "tableTo": "broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_insights_email_id_unique": {
+          "name": "email_insights_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_id"
+          ]
+        },
+        "email_insights_broadcast_id_unique": {
+          "name": "email_insights_broadcast_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "broadcast_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_insights_one_target": {
+          "name": "email_insights_one_target",
+          "value": "(\"email_insights\".\"email_id\" IS NULL) <> (\"email_insights\".\"broadcast_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_events": {
+      "name": "email_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "email_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sns_message_id": {
+          "name": "sns_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounce_type": {
+          "name": "bounce_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_events_email_idx": {
+          "name": "email_events_email_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_sns_message_id_idx": {
+          "name": "email_events_sns_message_id_idx",
+          "columns": [
+            {
+              "expression": "sns_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_events\".\"sns_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_data_unstripped_idx": {
+          "name": "email_events_data_unstripped_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_events\".\"data\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_sns_created_idx": {
+          "name": "email_events_sns_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_events\".\"sns_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_events_email_id_emails_id_fk": {
+          "name": "email_events_email_id_emails_id_fk",
+          "tableFrom": "email_events",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_message_id": {
+          "name": "ses_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_status": {
+          "name": "latest_status",
+          "type": "email_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "body_ciphertext": {
+          "name": "body_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_iv": {
+          "name": "body_iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_wrapped_dek": {
+          "name": "body_wrapped_dek",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_key_version": {
+          "name": "body_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_purged_at": {
+          "name": "body_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "emails_team_created_idx": {
+          "name": "emails_team_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_ses_message_id_idx": {
+          "name": "emails_ses_message_id_idx",
+          "columns": [
+            {
+              "expression": "ses_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"emails\".\"ses_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_body_unpurged_idx": {
+          "name": "emails_body_unpurged_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"body_purged_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_sent_at_idx": {
+          "name": "emails_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"sent_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_team_quota_parked_idx": {
+          "name": "emails_team_quota_parked_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"latest_status\" = 'queued_quota'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_quota_parked_created_idx": {
+          "name": "emails_quota_parked_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"latest_status\" = 'queued_quota'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_queued_created_idx": {
+          "name": "emails_queued_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"latest_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_created_idx": {
+          "name": "emails_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_team_status_created_idx": {
+          "name": "emails_team_status_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "latest_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_broadcast_contact_idx": {
+          "name": "emails_broadcast_contact_idx",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"emails\".\"broadcast_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "emails_team_id_teams_id_fk": {
+          "name": "emails_team_id_teams_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "emails_domain_id_domains_id_fk": {
+          "name": "emails_domain_id_domains_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "emails_broadcast_id_broadcasts_id_fk": {
+          "name": "emails_broadcast_id_broadcasts_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "emails_topic_id_topics_id_fk": {
+          "name": "emails_topic_id_topics_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_hash": {
+          "name": "body_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_email_ids": {
+          "name": "response_email_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idempotency_expiry_idx": {
+          "name": "idempotency_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_team_id_teams_id_fk": {
+          "name": "idempotency_keys_team_id_teams_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotency_keys_team_id_key_pk": {
+          "name": "idempotency_keys_team_id_key_pk",
+          "columns": [
+            "team_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "ses_max_send_rate": {
+          "name": "ses_max_send_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_retention_days": {
+          "name": "email_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "instance_settings_single_row": {
+          "name": "instance_settings_single_row",
+          "value": "\"instance_settings\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.region_breakers": {
+      "name": "region_breakers",
+      "schema": "",
+      "columns": {
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_members": {
+      "name": "segment_members",
+      "schema": "",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "segment_members_contact_idx": {
+          "name": "segment_members_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "segment_members_segment_created_idx": {
+          "name": "segment_members_segment_created_idx",
+          "columns": [
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "segment_members_segment_id_segments_id_fk": {
+          "name": "segment_members_segment_id_segments_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_members_contact_id_contacts_id_fk": {
+          "name": "segment_members_contact_id_contacts_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "segment_members_segment_id_contact_id_pk": {
+          "name": "segment_members_segment_id_contact_id_pk",
+          "columns": [
+            "segment_id",
+            "contact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_count": {
+          "name": "contact_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_count": {
+          "name": "unsubscribed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counted_at": {
+          "name": "counted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "segments_team_idx": {
+          "name": "segments_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "segments_team_id_teams_id_fk": {
+          "name": "segments_team_id_teams_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppressions": {
+      "name": "suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_email_id": {
+          "name": "source_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "suppressions_team_hash_idx": {
+          "name": "suppressions_team_hash_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppressions_team_id_teams_id_fk": {
+          "name": "suppressions_team_id_teams_id_fk",
+          "tableFrom": "suppressions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_invitations": {
+      "name": "team_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "send_count": {
+          "name": "send_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_invitations_team_email_pending_idx": {
+          "name": "team_invitations_team_email_pending_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_invitations\".\"accepted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_invitations_team_id_teams_id_fk": {
+          "name": "team_invitations_team_id_teams_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_by_user_id_user_id_fk": {
+          "name": "team_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_notifications": {
+      "name": "team_notifications",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_notifications_team_id_teams_id_fk": {
+          "name": "team_notifications_team_id_teams_id_fk",
+          "tableFrom": "team_notifications",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_notifications_team_id_kind_period_key_pk": {
+          "name": "team_notifications_team_id_kind_period_key_pk",
+          "columns": [
+            "team_id",
+            "kind",
+            "period_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_status": {
+          "name": "plan_status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_tenant_name": {
+          "name": "ses_tenant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_brand_name": {
+          "name": "unsubscribe_brand_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_message": {
+          "name": "unsubscribe_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_redirect_url": {
+          "name": "unsubscribe_redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_background_color": {
+          "name": "unsubscribe_background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_text_color": {
+          "name": "unsubscribe_text_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_accent_color": {
+          "name": "unsubscribe_accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_hide_branding": {
+          "name": "unsubscribe_hide_branding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unsubscribe_logo_radius": {
+          "name": "unsubscribe_logo_radius",
+          "type": "unsubscribe_logo_radius",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gentle'"
+        },
+        "unsubscribe_success_message": {
+          "name": "unsubscribe_success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_powered_by": {
+          "name": "unsubscribe_powered_by",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "teams_unsubscribe_background_color_hex": {
+          "name": "teams_unsubscribe_background_color_hex",
+          "value": "\"teams\".\"unsubscribe_background_color\" ~ '^#[0-9a-fA-F]{6}$'"
+        },
+        "teams_unsubscribe_text_color_hex": {
+          "name": "teams_unsubscribe_text_color_hex",
+          "value": "\"teams\".\"unsubscribe_text_color\" ~ '^#[0-9a-fA-F]{6}$'"
+        },
+        "teams_unsubscribe_accent_color_hex": {
+          "name": "teams_unsubscribe_accent_color_hex",
+          "value": "\"teams\".\"unsubscribe_accent_color\" ~ '^#[0-9a-fA-F]{6}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_team_idx": {
+          "name": "templates_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_team_alias_idx": {
+          "name": "templates_team_alias_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_team_id_teams_id_fk": {
+          "name": "templates_team_id_teams_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_topic_subscriptions": {
+      "name": "contact_topic_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_topic_unique": {
+          "name": "contact_topic_unique",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_topic_subscriptions_contact_id_contacts_id_fk": {
+          "name": "contact_topic_subscriptions_contact_id_contacts_id_fk",
+          "tableFrom": "contact_topic_subscriptions",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_topic_subscriptions_topic_id_topics_id_fk": {
+          "name": "contact_topic_subscriptions_topic_id_topics_id_fk",
+          "tableFrom": "contact_topic_subscriptions",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_subscribed": {
+          "name": "default_subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "topic_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_team_idx": {
+          "name": "topics_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_team_id_teams_id_fk": {
+          "name": "topics_team_id_teams_id_fk",
+          "tableFrom": "topics",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_counters": {
+      "name": "usage_counters",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent": {
+          "name": "sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "delivered": {
+          "name": "delivered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bounced": {
+          "name": "bounced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hard_bounced": {
+          "name": "hard_bounced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "complained": {
+          "name": "complained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opened": {
+          "name": "opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clicked": {
+          "name": "clicked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prefetched": {
+          "name": "prefetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "usage_counters_day_idx": {
+          "name": "usage_counters_day_idx",
+          "columns": [
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_counters_team_id_teams_id_fk": {
+          "name": "usage_counters_team_id_teams_id_fk",
+          "tableFrom": "usage_counters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "usage_counters_team_id_day_pk": {
+          "name": "usage_counters_team_id_day_pk",
+          "columns": [
+            "team_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_counters_hourly": {
+      "name": "usage_counters_hourly",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent": {
+          "name": "sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "delivered": {
+          "name": "delivered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bounced": {
+          "name": "bounced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hard_bounced": {
+          "name": "hard_bounced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "complained": {
+          "name": "complained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opened": {
+          "name": "opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clicked": {
+          "name": "clicked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prefetched": {
+          "name": "prefetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "usage_counters_hourly_hour_idx": {
+          "name": "usage_counters_hourly_hour_idx",
+          "columns": [
+            {
+              "expression": "hour",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_counters_hourly_team_id_teams_id_fk": {
+          "name": "usage_counters_hourly_team_id_teams_id_fk",
+          "tableFrom": "usage_counters_hourly",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "usage_counters_hourly_team_id_hour_pk": {
+          "name": "usage_counters_hourly_team_id_hour_pk",
+          "columns": [
+            "team_id",
+            "hour"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_code": {
+          "name": "last_response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_created_idx": {
+          "name": "webhook_deliveries_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_open_idx": {
+          "name": "webhook_deliveries_open_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" in ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" in ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_endpoint_settled_idx": {
+          "name": "webhook_deliveries_endpoint_settled_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" = 'success' or (\"webhook_deliveries\".\"status\" = 'exhausted' and (\"webhook_deliveries\".\"attempts\" >= 6 or \"webhook_deliveries\".\"last_response_code\" = 429))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_unstripped_idx": {
+          "name": "webhook_deliveries_unstripped_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"payload\" ? 'data' or \"webhook_deliveries\".\"last_response_body\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_wrapped_dek": {
+          "name": "secret_wrapped_dek",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_key_version": {
+          "name": "secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_last4": {
+          "name": "secret_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_secret_ciphertext": {
+          "name": "prev_secret_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_iv": {
+          "name": "prev_secret_iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_wrapped_dek": {
+          "name": "prev_secret_wrapped_dek",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_key_version": {
+          "name": "prev_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_expires_at": {
+          "name": "prev_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enabled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_endpoints_team_id_teams_id_fk": {
+          "name": "webhook_endpoints_team_id_teams_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.api_key_permission": {
+      "name": "api_key_permission",
+      "schema": "public",
+      "values": [
+        "full_access",
+        "sending_access"
+      ]
+    },
+    "public.team_member_role": {
+      "name": "team_member_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.broadcast_status": {
+      "name": "broadcast_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "sending",
+        "sent",
+        "canceled"
+      ]
+    },
+    "public.contact_property_type": {
+      "name": "contact_property_type",
+      "schema": "public",
+      "values": [
+        "string",
+        "number"
+      ]
+    },
+    "public.domain_status": {
+      "name": "domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "temporary_failure",
+        "failed"
+      ]
+    },
+    "public.tls_mode": {
+      "name": "tls_mode",
+      "schema": "public",
+      "values": [
+        "opportunistic",
+        "enforced"
+      ]
+    },
+    "public.email_event_type": {
+      "name": "email_event_type",
+      "schema": "public",
+      "values": [
+        "queued",
+        "queued_quota",
+        "sent",
+        "delivery_delayed",
+        "delivered",
+        "opened",
+        "clicked",
+        "bounced",
+        "complained",
+        "suppressed",
+        "rendering_failure",
+        "failed",
+        "prefetched",
+        "unsubscribed"
+      ]
+    },
+    "public.email_status": {
+      "name": "email_status",
+      "schema": "public",
+      "values": [
+        "queued_quota",
+        "queued",
+        "sent",
+        "delivery_delayed",
+        "delivered",
+        "opened",
+        "clicked",
+        "bounced",
+        "complained",
+        "suppressed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.suppression_reason": {
+      "name": "suppression_reason",
+      "schema": "public",
+      "values": [
+        "hard_bounce",
+        "complaint",
+        "manual",
+        "one_click_unsubscribe"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "scale"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "active",
+        "trialing",
+        "past_due",
+        "unpaid",
+        "canceled",
+        "incomplete"
+      ]
+    },
+    "public.unsubscribe_logo_radius": {
+      "name": "unsubscribe_logo_radius",
+      "schema": "public",
+      "values": [
+        "square",
+        "gentle",
+        "rounded",
+        "circle"
+      ]
+    },
+    "public.topic_visibility": {
+      "name": "topic_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.webhook_delivery_status": {
+      "name": "webhook_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed",
+        "exhausted"
+      ]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": [
+        "enabled",
+        "disabled",
+        "auto_disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0034_snapshot.json
+++ b/packages/db/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,5558 @@
+{
+  "id": "eef7b755-0e42-4685-8a8b-c50e87c969a1",
+  "prevId": "5548d277-49b3-4b9b-8f78-9f0f1db9f1ec",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_prefix": {
+          "name": "token_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last4": {
+          "name": "last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permission": {
+          "name": "permission",
+          "type": "api_key_permission",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full_access'"
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_api_key_id": {
+          "name": "created_by_api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_token_prefix_idx": {
+          "name": "api_keys_token_prefix_idx",
+          "columns": [
+            {
+              "expression": "token_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_team_id_teams_id_fk": {
+          "name": "api_keys_team_id_teams_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_domain_id_domains_id_fk": {
+          "name": "api_keys_domain_id_domains_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_api_key_id_api_keys_id_fk": {
+          "name": "api_keys_created_by_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "created_by_api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_rate_limits": {
+      "name": "api_rate_limits",
+      "schema": "",
+      "columns": {
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window_start": {
+          "name": "window_start",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_rate_limits_api_key_id_api_keys_id_fk": {
+          "name": "api_rate_limits_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_rate_limits",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_requests": {
+      "name": "api_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_bytes": {
+          "name": "request_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_bytes": {
+          "name": "response_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_body": {
+          "name": "request_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_body": {
+          "name": "response_body",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "api_requests_team_created_idx": {
+          "name": "api_requests_team_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_requests_created_idx": {
+          "name": "api_requests_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_requests_team_oauth_client_idx": {
+          "name": "api_requests_team_oauth_client_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_requests\".\"oauth_client_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_requests_team_id_teams_id_fk": {
+          "name": "api_requests_team_id_teams_id_fk",
+          "tableFrom": "api_requests",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_requests_api_key_id_api_keys_id_fk": {
+          "name": "api_requests_api_key_id_api_keys_id_fk",
+          "tableFrom": "api_requests",
+          "tableTo": "api_keys",
+          "columnsFrom": [
+            "api_key_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_team_idx": {
+          "name": "audit_log_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_recent_idx": {
+          "name": "audit_log_action_recent_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_issuer_account_id_idx": {
+          "name": "account_issuer_account_id_idx",
+          "columns": [
+            {
+              "expression": "issuer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alg": {
+          "name": "alg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crv": {
+          "name": "crv",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_token": {
+      "name": "oauth_access_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_access_token_client_id_idx": {
+          "name": "oauth_access_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_session_id_idx": {
+          "name": "oauth_access_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_user_id_idx": {
+          "name": "oauth_access_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_authorization_code_id_idx": {
+          "name": "oauth_access_token_authorization_code_id_idx",
+          "columns": [
+            {
+              "expression": "authorization_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_access_token_refresh_id_idx": {
+          "name": "oauth_access_token_refresh_id_idx",
+          "columns": [
+            {
+              "expression": "refresh_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_access_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_access_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_session_id_session_id_fk": {
+          "name": "oauth_access_token_session_id_session_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_user_id_user_id_fk": {
+          "name": "oauth_access_token_user_id_user_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_token_refresh_id_oauth_refresh_token_id_fk": {
+          "name": "oauth_access_token_refresh_id_oauth_refresh_token_id_fk",
+          "tableFrom": "oauth_access_token",
+          "tableTo": "oauth_refresh_token",
+          "columnsFrom": [
+            "refresh_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_token_token_unique": {
+          "name": "oauth_access_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_discovery_id": {
+          "name": "client_discovery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "skip_consent": {
+          "name": "skip_consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_credentials_scopes": {
+          "name": "client_credentials_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backchannel_logout_uri": {
+          "name": "backchannel_logout_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "backchannel_logout_session_required": {
+          "name": "backchannel_logout_session_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_type": {
+          "name": "application_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks": {
+          "name": "jwks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "jwks_uri": {
+          "name": "jwks_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpop_bound_access_tokens": {
+          "name": "dpop_bound_access_tokens",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_client_user_id_idx": {
+          "name": "oauth_client_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_user_id_user_id_fk": {
+          "name": "oauth_client_user_id_user_id_fk",
+          "tableFrom": "oauth_client",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_client_client_id_unique": {
+          "name": "oauth_client_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client_assertion": {
+      "name": "oauth_client_assertion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client_resource": {
+      "name": "oauth_client_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_client_resource_client_id_idx": {
+          "name": "oauth_client_resource_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_client_resource_resource_id_idx": {
+          "name": "oauth_client_resource_resource_id_idx",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_client_resource_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_client_resource_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_client_resource",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_client_resource_resource_id_oauth_resource_identifier_fk": {
+          "name": "oauth_client_resource_resource_id_oauth_resource_identifier_fk",
+          "tableFrom": "oauth_client_resource",
+          "tableTo": "oauth_resource",
+          "columnsFrom": [
+            "resource_id"
+          ],
+          "columnsTo": [
+            "identifier"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_consent": {
+      "name": "oauth_consent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_consent_client_id_idx": {
+          "name": "oauth_consent_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_user_id_idx": {
+          "name": "oauth_consent_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_consent_reference_id_idx": {
+          "name": "oauth_consent_reference_id_idx",
+          "columns": [
+            {
+              "expression": "reference_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_consent_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_consent_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consent_user_id_user_id_fk": {
+          "name": "oauth_consent_user_id_user_id_fk",
+          "tableFrom": "oauth_consent",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_token": {
+      "name": "oauth_refresh_token",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authorization_code_id": {
+          "name": "authorization_code_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requested_user_info_claims": {
+          "name": "requested_user_info_claims",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_replay_response": {
+          "name": "rotation_replay_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotation_replay_expires_at": {
+          "name": "rotation_replay_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation": {
+          "name": "confirmation",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "oauth_refresh_token_client_id_idx": {
+          "name": "oauth_refresh_token_client_id_idx",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_session_id_idx": {
+          "name": "oauth_refresh_token_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_user_id_idx": {
+          "name": "oauth_refresh_token_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_refresh_token_authorization_code_id_idx": {
+          "name": "oauth_refresh_token_authorization_code_id_idx",
+          "columns": [
+            {
+              "expression": "authorization_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_refresh_token_client_id_oauth_client_client_id_fk": {
+          "name": "oauth_refresh_token_client_id_oauth_client_client_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "client_id"
+          ],
+          "columnsTo": [
+            "client_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_session_id_session_id_fk": {
+          "name": "oauth_refresh_token_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "session",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_token_user_id_user_id_fk": {
+          "name": "oauth_refresh_token_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_token",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_token_token_unique": {
+          "name": "oauth_refresh_token_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_resource": {
+      "name": "oauth_resource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_ttl": {
+          "name": "access_token_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_ttl": {
+          "name": "refresh_token_ttl",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_algorithm": {
+          "name": "signing_algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signing_key_id": {
+          "name": "signing_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_scopes": {
+          "name": "allowed_scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_claims": {
+          "name": "custom_claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dpop_bound_access_tokens_required": {
+          "name": "dpop_bound_access_tokens_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy_version": {
+          "name": "policy_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_resource_identifier_unique": {
+          "name": "oauth_resource_identifier_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "identifier"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "active_team_id": {
+          "name": "active_team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_members_team_user_idx": {
+          "name": "team_members_team_user_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_user_id_user_id_fk": {
+          "name": "team_members_user_id_user_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_opt_outs": {
+          "name": "mail_opt_outs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.broadcasts": {
+      "name": "broadcasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preview_text": {
+          "name": "preview_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "broadcast_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient_count": {
+          "name": "recipient_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_count": {
+          "name": "delivered_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounced_count": {
+          "name": "bounced_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "complained_count": {
+          "name": "complained_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "broadcasts_team_idx": {
+          "name": "broadcasts_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "broadcasts_team_id_teams_id_fk": {
+          "name": "broadcasts_team_id_teams_id_fk",
+          "tableFrom": "broadcasts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "broadcasts_topic_id_topics_id_fk": {
+          "name": "broadcasts_topic_id_topics_id_fk",
+          "tableFrom": "broadcasts",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "broadcasts_segment_id_segments_id_fk": {
+          "name": "broadcasts_segment_id_segments_id_fk",
+          "tableFrom": "broadcasts",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_activities": {
+      "name": "contact_activities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_activities_contact_idx": {
+          "name": "contact_activities_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_activities_team_id_teams_id_fk": {
+          "name": "contact_activities_team_id_teams_id_fk",
+          "tableFrom": "contact_activities",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_activities_contact_id_contacts_id_fk": {
+          "name": "contact_activities_contact_id_contacts_id_fk",
+          "tableFrom": "contact_activities",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_properties": {
+      "name": "contact_properties",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "contact_property_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'string'"
+        },
+        "fallback_value": {
+          "name": "fallback_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_properties_team_key_idx": {
+          "name": "contact_properties_team_key_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"key\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_properties_team_id_teams_id_fk": {
+          "name": "contact_properties_team_id_teams_id_fk",
+          "tableFrom": "contact_properties",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "unsubscribed": {
+          "name": "unsubscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "unsubscribed_at": {
+          "name": "unsubscribed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contacts_team_email_idx": {
+          "name": "contacts_team_email_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_team_created_idx": {
+          "name": "contacts_team_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_team_id_idx": {
+          "name": "contacts_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "contacts_team_updated_idx": {
+          "name": "contacts_team_updated_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contacts_team_id_teams_id_fk": {
+          "name": "contacts_team_id_teams_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.domains": {
+      "name": "domains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "domain_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "dkim_selector": {
+          "name": "dkim_selector",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dkim_public_key": {
+          "name": "dkim_public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mail_from_subdomain": {
+          "name": "mail_from_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'send'"
+        },
+        "tracking_subdomain": {
+          "name": "tracking_subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_subdomain_set_at": {
+          "name": "tracking_subdomain_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "click_tracking": {
+          "name": "click_tracking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "open_tracking": {
+          "name": "open_tracking",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tls_mode": {
+          "name": "tls_mode",
+          "type": "tls_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opportunistic'"
+        },
+        "ses_configuration_set": {
+          "name": "ses_configuration_set",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_tenant_associated_at": {
+          "name": "ses_tenant_associated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_tenant_config_set": {
+          "name": "ses_tenant_config_set",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dns_records": {
+          "name": "dns_records",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dmarc_policy": {
+          "name": "dmarc_policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dmarc_checked_at": {
+          "name": "dmarc_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_checked_at": {
+          "name": "last_checked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "domains_team_name_idx": {
+          "name": "domains_team_name_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "domains_team_id_teams_id_fk": {
+          "name": "domains_team_id_teams_id_fk",
+          "tableFrom": "domains",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_insights": {
+      "name": "email_insights",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketing": {
+          "name": "marketing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checks": {
+          "name": "checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_tenths": {
+          "name": "score_tenths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score_version": {
+          "name": "score_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "html_size_bytes": {
+          "name": "html_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_size_bytes": {
+          "name": "mime_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_insights_team_id_teams_id_fk": {
+          "name": "email_insights_team_id_teams_id_fk",
+          "tableFrom": "email_insights",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_insights_email_id_emails_id_fk": {
+          "name": "email_insights_email_id_emails_id_fk",
+          "tableFrom": "email_insights",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_insights_broadcast_id_broadcasts_id_fk": {
+          "name": "email_insights_broadcast_id_broadcasts_id_fk",
+          "tableFrom": "email_insights",
+          "tableTo": "broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_insights_email_id_unique": {
+          "name": "email_insights_email_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email_id"
+          ]
+        },
+        "email_insights_broadcast_id_unique": {
+          "name": "email_insights_broadcast_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "broadcast_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "email_insights_one_target": {
+          "name": "email_insights_one_target",
+          "value": "(\"email_insights\".\"email_id\" IS NULL) <> (\"email_insights\".\"broadcast_id\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.email_events": {
+      "name": "email_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "email_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sns_message_id": {
+          "name": "sns_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounce_type": {
+          "name": "bounce_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_events_email_idx": {
+          "name": "email_events_email_idx",
+          "columns": [
+            {
+              "expression": "email_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_sns_message_id_idx": {
+          "name": "email_events_sns_message_id_idx",
+          "columns": [
+            {
+              "expression": "sns_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"email_events\".\"sns_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_data_unstripped_idx": {
+          "name": "email_events_data_unstripped_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_events\".\"data\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_events_sns_created_idx": {
+          "name": "email_events_sns_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_events\".\"sns_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_events_email_id_emails_id_fk": {
+          "name": "email_events_email_id_emails_id_fk",
+          "tableFrom": "email_events",
+          "tableTo": "emails",
+          "columnsFrom": [
+            "email_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.emails": {
+      "name": "emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain_id": {
+          "name": "domain_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_message_id": {
+          "name": "ses_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from": {
+          "name": "from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cc": {
+          "name": "cc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bcc": {
+          "name": "bcc",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_to": {
+          "name": "reply_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attachments": {
+          "name": "attachments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latest_status": {
+          "name": "latest_status",
+          "type": "email_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "body_ciphertext": {
+          "name": "body_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_iv": {
+          "name": "body_iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_wrapped_dek": {
+          "name": "body_wrapped_dek",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_key_version": {
+          "name": "body_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_purged_at": {
+          "name": "body_purged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "emails_team_created_idx": {
+          "name": "emails_team_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_ses_message_id_idx": {
+          "name": "emails_ses_message_id_idx",
+          "columns": [
+            {
+              "expression": "ses_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"emails\".\"ses_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_body_unpurged_idx": {
+          "name": "emails_body_unpurged_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"body_purged_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_sent_at_idx": {
+          "name": "emails_sent_at_idx",
+          "columns": [
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"sent_at\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_team_quota_parked_idx": {
+          "name": "emails_team_quota_parked_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"latest_status\" = 'queued_quota'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_quota_parked_created_idx": {
+          "name": "emails_quota_parked_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"latest_status\" = 'queued_quota'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_queued_created_idx": {
+          "name": "emails_queued_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"emails\".\"latest_status\" = 'queued'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_created_idx": {
+          "name": "emails_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_team_status_created_idx": {
+          "name": "emails_team_status_created_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "latest_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "emails_broadcast_contact_idx": {
+          "name": "emails_broadcast_contact_idx",
+          "columns": [
+            {
+              "expression": "broadcast_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"emails\".\"broadcast_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "emails_team_id_teams_id_fk": {
+          "name": "emails_team_id_teams_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "emails_domain_id_domains_id_fk": {
+          "name": "emails_domain_id_domains_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "domains",
+          "columnsFrom": [
+            "domain_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "emails_broadcast_id_broadcasts_id_fk": {
+          "name": "emails_broadcast_id_broadcasts_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "broadcasts",
+          "columnsFrom": [
+            "broadcast_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "emails_topic_id_topics_id_fk": {
+          "name": "emails_topic_id_topics_id_fk",
+          "tableFrom": "emails",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.idempotency_keys": {
+      "name": "idempotency_keys",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_hash": {
+          "name": "body_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response_email_ids": {
+          "name": "response_email_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idempotency_expiry_idx": {
+          "name": "idempotency_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "idempotency_keys_team_id_teams_id_fk": {
+          "name": "idempotency_keys_team_id_teams_id_fk",
+          "tableFrom": "idempotency_keys",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "idempotency_keys_team_id_key_pk": {
+          "name": "idempotency_keys_team_id_key_pk",
+          "columns": [
+            "team_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instance_settings": {
+      "name": "instance_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "smallint",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "ses_max_send_rate": {
+          "name": "ses_max_send_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_retention_days": {
+          "name": "email_retention_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "instance_settings_single_row": {
+          "name": "instance_settings_single_row",
+          "value": "\"instance_settings\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.region_breakers": {
+      "name": "region_breakers",
+      "schema": "",
+      "columns": {
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused_at": {
+          "name": "paused_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segment_members": {
+      "name": "segment_members",
+      "schema": "",
+      "columns": {
+        "segment_id": {
+          "name": "segment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "segment_members_contact_idx": {
+          "name": "segment_members_contact_idx",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "segment_members_segment_created_idx": {
+          "name": "segment_members_segment_created_idx",
+          "columns": [
+            {
+              "expression": "segment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "segment_members_segment_id_segments_id_fk": {
+          "name": "segment_members_segment_id_segments_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "segment_members_contact_id_contacts_id_fk": {
+          "name": "segment_members_contact_id_contacts_id_fk",
+          "tableFrom": "segment_members",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "segment_members_segment_id_contact_id_pk": {
+          "name": "segment_members_segment_id_contact_id_pk",
+          "columns": [
+            "segment_id",
+            "contact_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.segments": {
+      "name": "segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_count": {
+          "name": "contact_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribed_count": {
+          "name": "unsubscribed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "counted_at": {
+          "name": "counted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "segments_team_idx": {
+          "name": "segments_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "segments_team_id_teams_id_fk": {
+          "name": "segments_team_id_teams_id_fk",
+          "tableFrom": "segments",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_events": {
+      "name": "stripe_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suppressions": {
+      "name": "suppressions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "suppression_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_email_id": {
+          "name": "source_email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "suppressions_team_hash_idx": {
+          "name": "suppressions_team_hash_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suppressions_team_id_teams_id_fk": {
+          "name": "suppressions_team_id_teams_id_fk",
+          "tableFrom": "suppressions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_invitations": {
+      "name": "team_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "team_member_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sent_at": {
+          "name": "last_sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "send_count": {
+          "name": "send_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "team_invitations_team_email_pending_idx": {
+          "name": "team_invitations_team_email_pending_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lower(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"team_invitations\".\"accepted_at\" is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "team_invitations_team_id_teams_id_fk": {
+          "name": "team_invitations_team_id_teams_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_invitations_invited_by_user_id_user_id_fk": {
+          "name": "team_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "team_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.team_notifications": {
+      "name": "team_notifications",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_key": {
+          "name": "period_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_notifications_team_id_teams_id_fk": {
+          "name": "team_notifications_team_id_teams_id_fk",
+          "tableFrom": "team_notifications",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_notifications_team_id_kind_period_key_pk": {
+          "name": "team_notifications_team_id_kind_period_key_pk",
+          "columns": [
+            "team_id",
+            "kind",
+            "period_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan": {
+          "name": "plan",
+          "type": "plan",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_status": {
+          "name": "plan_status",
+          "type": "plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at": {
+          "name": "cancel_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ses_tenant_name": {
+          "name": "ses_tenant_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_brand_name": {
+          "name": "unsubscribe_brand_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_message": {
+          "name": "unsubscribe_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_redirect_url": {
+          "name": "unsubscribe_redirect_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_background_color": {
+          "name": "unsubscribe_background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_text_color": {
+          "name": "unsubscribe_text_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_accent_color": {
+          "name": "unsubscribe_accent_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_hide_branding": {
+          "name": "unsubscribe_hide_branding",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "unsubscribe_logo_radius": {
+          "name": "unsubscribe_logo_radius",
+          "type": "unsubscribe_logo_radius",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'gentle'"
+        },
+        "unsubscribe_success_message": {
+          "name": "unsubscribe_success_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unsubscribe_powered_by": {
+          "name": "unsubscribe_powered_by",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "teams_stripe_customer_id_unique": {
+          "name": "teams_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "teams_unsubscribe_background_color_hex": {
+          "name": "teams_unsubscribe_background_color_hex",
+          "value": "\"teams\".\"unsubscribe_background_color\" ~ '^#[0-9a-fA-F]{6}$'"
+        },
+        "teams_unsubscribe_text_color_hex": {
+          "name": "teams_unsubscribe_text_color_hex",
+          "value": "\"teams\".\"unsubscribe_text_color\" ~ '^#[0-9a-fA-F]{6}$'"
+        },
+        "teams_unsubscribe_accent_color_hex": {
+          "name": "teams_unsubscribe_accent_color_hex",
+          "value": "\"teams\".\"unsubscribe_accent_color\" ~ '^#[0-9a-fA-F]{6}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.templates": {
+      "name": "templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document": {
+          "name": "document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "templates_team_idx": {
+          "name": "templates_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "templates_team_alias_idx": {
+          "name": "templates_team_alias_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templates_team_id_teams_id_fk": {
+          "name": "templates_team_id_teams_id_fk",
+          "tableFrom": "templates",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contact_topic_subscriptions": {
+      "name": "contact_topic_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic_id": {
+          "name": "topic_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subscribed": {
+          "name": "subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contact_topic_unique": {
+          "name": "contact_topic_unique",
+          "columns": [
+            {
+              "expression": "contact_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "topic_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "contact_topic_subscriptions_contact_id_contacts_id_fk": {
+          "name": "contact_topic_subscriptions_contact_id_contacts_id_fk",
+          "tableFrom": "contact_topic_subscriptions",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_topic_subscriptions_topic_id_topics_id_fk": {
+          "name": "contact_topic_subscriptions_topic_id_topics_id_fk",
+          "tableFrom": "contact_topic_subscriptions",
+          "tableTo": "topics",
+          "columnsFrom": [
+            "topic_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.topics": {
+      "name": "topics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_subscribed": {
+          "name": "default_subscribed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "topic_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "topics_team_idx": {
+          "name": "topics_team_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "topics_team_id_teams_id_fk": {
+          "name": "topics_team_id_teams_id_fk",
+          "tableFrom": "topics",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_counters": {
+      "name": "usage_counters",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day": {
+          "name": "day",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent": {
+          "name": "sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "delivered": {
+          "name": "delivered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bounced": {
+          "name": "bounced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hard_bounced": {
+          "name": "hard_bounced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "complained": {
+          "name": "complained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opened": {
+          "name": "opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clicked": {
+          "name": "clicked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prefetched": {
+          "name": "prefetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "usage_counters_day_idx": {
+          "name": "usage_counters_day_idx",
+          "columns": [
+            {
+              "expression": "day",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_counters_team_id_teams_id_fk": {
+          "name": "usage_counters_team_id_teams_id_fk",
+          "tableFrom": "usage_counters",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "usage_counters_team_id_day_pk": {
+          "name": "usage_counters_team_id_day_pk",
+          "columns": [
+            "team_id",
+            "day"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_counters_hourly": {
+      "name": "usage_counters_hourly",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted": {
+          "name": "accepted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sent": {
+          "name": "sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "delivered": {
+          "name": "delivered",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bounced": {
+          "name": "bounced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "hard_bounced": {
+          "name": "hard_bounced",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "complained": {
+          "name": "complained",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "opened": {
+          "name": "opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "clicked": {
+          "name": "clicked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "prefetched": {
+          "name": "prefetched",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "usage_counters_hourly_hour_idx": {
+          "name": "usage_counters_hourly_hour_idx",
+          "columns": [
+            {
+              "expression": "hour",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "usage_counters_hourly_team_id_teams_id_fk": {
+          "name": "usage_counters_hourly_team_id_teams_id_fk",
+          "tableFrom": "usage_counters_hourly",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "usage_counters_hourly_team_id_hour_pk": {
+          "name": "usage_counters_hourly_team_id_hour_pk",
+          "columns": [
+            "team_id",
+            "hour"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_id": {
+          "name": "email_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_delivery_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_attempt_at": {
+          "name": "last_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_code": {
+          "name": "last_response_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_response_body": {
+          "name": "last_response_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "webhook_deliveries_endpoint_idx": {
+          "name": "webhook_deliveries_endpoint_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_created_idx": {
+          "name": "webhook_deliveries_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_open_idx": {
+          "name": "webhook_deliveries_open_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" in ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_due_idx": {
+          "name": "webhook_deliveries_due_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" in ('pending', 'failed')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_endpoint_settled_idx": {
+          "name": "webhook_deliveries_endpoint_settled_idx",
+          "columns": [
+            {
+              "expression": "endpoint_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"status\" = 'success' or (\"webhook_deliveries\".\"status\" = 'exhausted' and (\"webhook_deliveries\".\"attempts\" >= 6 or \"webhook_deliveries\".\"last_response_code\" = 429))",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "webhook_deliveries_unstripped_idx": {
+          "name": "webhook_deliveries_unstripped_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"webhook_deliveries\".\"payload\" ? 'data' or \"webhook_deliveries\".\"last_response_body\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk": {
+          "name": "webhook_deliveries_endpoint_id_webhook_endpoints_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhook_endpoints",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_endpoints": {
+      "name": "webhook_endpoints",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_ciphertext": {
+          "name": "secret_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_iv": {
+          "name": "secret_iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_wrapped_dek": {
+          "name": "secret_wrapped_dek",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_key_version": {
+          "name": "secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_last4": {
+          "name": "secret_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_secret_ciphertext": {
+          "name": "prev_secret_ciphertext",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_iv": {
+          "name": "prev_secret_iv",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_wrapped_dek": {
+          "name": "prev_secret_wrapped_dek",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_key_version": {
+          "name": "prev_secret_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_secret_expires_at": {
+          "name": "prev_secret_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "events": {
+          "name": "events",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "webhook_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'enabled'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webhook_endpoints_team_id_teams_id_fk": {
+          "name": "webhook_endpoints_team_id_teams_id_fk",
+          "tableFrom": "webhook_endpoints",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.api_key_permission": {
+      "name": "api_key_permission",
+      "schema": "public",
+      "values": [
+        "full_access",
+        "sending_access"
+      ]
+    },
+    "public.team_member_role": {
+      "name": "team_member_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "admin",
+        "member"
+      ]
+    },
+    "public.broadcast_status": {
+      "name": "broadcast_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "scheduled",
+        "sending",
+        "sent",
+        "canceled"
+      ]
+    },
+    "public.contact_property_type": {
+      "name": "contact_property_type",
+      "schema": "public",
+      "values": [
+        "string",
+        "number"
+      ]
+    },
+    "public.domain_status": {
+      "name": "domain_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "verified",
+        "temporary_failure",
+        "failed"
+      ]
+    },
+    "public.tls_mode": {
+      "name": "tls_mode",
+      "schema": "public",
+      "values": [
+        "opportunistic",
+        "enforced"
+      ]
+    },
+    "public.email_event_type": {
+      "name": "email_event_type",
+      "schema": "public",
+      "values": [
+        "queued",
+        "queued_quota",
+        "sent",
+        "delivery_delayed",
+        "delivered",
+        "opened",
+        "clicked",
+        "bounced",
+        "complained",
+        "suppressed",
+        "rendering_failure",
+        "failed",
+        "prefetched",
+        "unsubscribed"
+      ]
+    },
+    "public.email_status": {
+      "name": "email_status",
+      "schema": "public",
+      "values": [
+        "queued_quota",
+        "queued",
+        "sent",
+        "delivery_delayed",
+        "delivered",
+        "opened",
+        "clicked",
+        "bounced",
+        "complained",
+        "suppressed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.suppression_reason": {
+      "name": "suppression_reason",
+      "schema": "public",
+      "values": [
+        "hard_bounce",
+        "complaint",
+        "manual",
+        "one_click_unsubscribe"
+      ]
+    },
+    "public.plan": {
+      "name": "plan",
+      "schema": "public",
+      "values": [
+        "free",
+        "pro",
+        "scale"
+      ]
+    },
+    "public.plan_status": {
+      "name": "plan_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "active",
+        "trialing",
+        "past_due",
+        "unpaid",
+        "canceled",
+        "incomplete"
+      ]
+    },
+    "public.unsubscribe_logo_radius": {
+      "name": "unsubscribe_logo_radius",
+      "schema": "public",
+      "values": [
+        "square",
+        "gentle",
+        "rounded",
+        "circle"
+      ]
+    },
+    "public.topic_visibility": {
+      "name": "topic_visibility",
+      "schema": "public",
+      "values": [
+        "private",
+        "public"
+      ]
+    },
+    "public.webhook_delivery_status": {
+      "name": "webhook_delivery_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "success",
+        "failed",
+        "exhausted"
+      ]
+    },
+    "public.webhook_status": {
+      "name": "webhook_status",
+      "schema": "public",
+      "values": [
+        "enabled",
+        "disabled",
+        "auto_disabled"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1788917329637,
       "tag": "0033_account_emails",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1788921184349,
+      "tag": "0034_mail_opt_outs",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1788908199501,
       "tag": "0032_unsubscribe_powered_by",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1788917329637,
+      "tag": "0033_account_emails",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/audit.ts
+++ b/packages/db/src/schema/audit.ts
@@ -20,5 +20,9 @@ export const auditLog = pgTable(
     data: jsonb("data").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (t) => [index("audit_log_team_idx").on(t.teamId, t.createdAt)],
+  (t) => [
+    index("audit_log_team_idx").on(t.teamId, t.createdAt),
+    // The notification sweep reads recent rows of a few actions.
+    index("audit_log_action_recent_idx").on(t.action, t.createdAt),
+  ],
 );

--- a/packages/db/src/schema/auth.ts
+++ b/packages/db/src/schema/auth.ts
@@ -24,6 +24,9 @@ export const user = pgTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: boolean("email_verified").notNull().default(false),
   image: text("image"),
+  // Owner notices this person turned off, by preference key (core
+  // mail-preferences); mail about the account itself is never listed here.
+  mailOptOuts: jsonb("mail_opt_outs").$type<string[]>().notNull().default([]),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/packages/db/src/schema/teams.ts
+++ b/packages/db/src/schema/teams.ts
@@ -37,6 +37,10 @@ export const teams = pgTable(
     stripeSubscriptionId: text("stripe_subscription_id"),
     planStatus: planStatusEnum("plan_status").notNull().default("none"),
     currentPeriodEnd: timestamp("current_period_end", { withTimezone: true }),
+    // When Stripe will end the subscription (cancel_at); null while it renews.
+    // Mirrored so a scheduled cancellation is a visible transition and the
+    // reminder before it needs no Stripe call.
+    cancelAt: timestamp("cancel_at", { withTimezone: true }),
     // SES tenant name for cloud reputation isolation; null on self-host.
     sesTenantName: text("ses_tenant_name"),
     // Per-team customization of the hosted unsubscribe pages. All null =


### PR DESCRIPTION
## Why

An instance already mailed people about password resets, verification, invitations, quota and deliverability, and nothing else. Everything a team owner would want to hear about the moment it happens — a domain that verified or stopped verifying, a key someone minted, a webhook secret rotated, a member who joined, a broadcast that went out or got held, the plan changing under them — was only visible by opening the dashboard. And the account itself got no welcome, no receipt for a password change, no word when an MCP app was granted access to act in the person's name.

## What changes

One card, one catalog, each reader's own language. Every account mail now renders on the shared card in `packages/core` from a catalog with `en` and `pt-BR` entries (18 kinds); the dashboard's reset/verify/invite mails and the worker's existing notices moved onto the same card byte-for-byte. Owner notices read in the language of the owner's contact in the team that holds the sender's domain (the row sign-up enrolls), English otherwise.

**To the person, sent from the request**

- **Welcome**, once the address is theirs (after the verification link, or at sign-up where the instance does not verify), naming the two first steps and the docs. Every admitted account gets it, including on a closed self-host that enrolls nobody.
- **Password changed**, after a reset goes through, pointing at a fresh reset rather than any token.
- **App connected**, after `/oauth2/consent` is accepted: app name, team (or all teams), scopes, and the revoke page. A re-consent to the same app is silent; the provider stamps a new consent with one instant for both dates and moves only `updatedAt` afterwards.

**To a team's owners**

- **Stripe route** (cloud): plan activated, moved between paid plans, ended (immediate cancellation included), a scheduled cancellation, and a failed charge with Stripe's next attempt or the lack of one and the hosted invoice as the button. Read off the team row before and after the event, so a redelivered or reordered event says nothing twice; a failed charge is claimed per invoice attempt, a downgrade per period end.
- **Worker sweep** (every ten minutes), three new detectors:
  - Domains: an episode claim per domain that verified at least once, so gaining or losing verification mails once wherever the change came from (dashboard, REST, re-verify cron). A domain SES gave up on (identity gone, or DKIM records missing past the 72-hour window) says to add it again.
  - Audit rows: `api_key.created` (also to whoever created it, with prefix, last four, permission and domain scope), `webhook.secret_rotated` (host, old secret's deadline), `member.joined` (to the other owners). Claimed by row id within a day; a row for a deleted team is skipped.
  - Cloud billing: a cancellation three days out, and a paid period that lapsed past its grace without Stripe saying so, keyed like the route's downgrade claim so the two never both speak.
- **Broadcast fan-out**: one report per broadcast after the sent flip — the sent count and link, or the quota notice when anything parked as `queued_quota` — and one notice when its region is held by the platform breaker, however many 15-minute waits follow.

**Schema.** `teams.cancel_at` mirrors Stripe's scheduled cancellation; `audit_log (action, created_at)` index for the sweep; migration 0033 seeds claims for domains already verified and for day-old audit rows so an upgrading instance does not replay history. A domain demoted at the moment of the upgrade is reported as lost on the first sweep (documented).

**Notification preferences.** A new **Settings → Notifications** tab lists every owner notice as a switch, grouped (domains, team, broadcasts, sending health, webhooks, billing on the cloud). A person's choices apply to every team they own and are honoured at the one place owner recipients are resolved, so the sweep, the fan-out and the Stripe route all read them. Severity steps of one notice fold into one switch; mail about the account itself and the security receipts for keys and webhook secrets are always sent. Stored as the keys turned off (`user.mail_opt_outs`, migration 0034), so a switch added later is on for everyone; writes are jsonb set operations, so two tabs cannot undo each other.

**Also:** a closed instance now tells a registrant that sign-up is disabled instead of better-auth's generic "check your inbox", and the cloud enrolls accounts whatever the sign-up flag says.

No new environment variable: `AUTH_EMAIL_FROM` carries the mails to a person, `NOTIFICATIONS_EMAIL_FROM` (falling back to it) the owner notices, as before.

## Verification

- Suites green across core, web, worker, billing, api, config and ses on PGlite. New: catalog parity and escaping (every kind, both languages), owner-locale lookup, `cancel_at` mirroring, welcome/receipt/consent flows through the real auth handler (the consent repeat via `prompt=consent`), the Stripe route's six mails with redelivery, the sweep's domain episodes, audit receipts, cloud billing reminders and grace lapse, pt-BR owners, and the broadcast sent/held-quota/held-region reports across resumed runs.
- Preferences: router get/set (idempotent off, unknown key refused), the owner filter per kind in core (folded kinds, always-sent kinds untouched), and a sweep test where an opted-out owner still gets the key receipt.
- Repo-wide biome and typecheck clean (the catalog test's `extra` field now typechecks).
- An adversarial review pass over the diff (four dimensions, fourteen findings, two refuted) produced the last commit: claims on every billing mail because Stripe delivers a checkout's events in parallel, a shared `planMove` so the route, the daily reconcile and the grace sweep agree on the mail and its key (the reconcile previously moved a plan silently), the downgrade dated at the earliest of cancel, period end and today, the reminder pre-claimed when a cancellation is scheduled inside its window, two sentences that presupposed a retry or an overlap, the notifications sender on the route's owner mails, a membership check before adding a key's creator, and a verification test that now opens the link over HTTP.

## Left out, on purpose

Email-changed and change-password (dashboard) receipts; localizing the worker's pre-existing quota/deliverability/webhook notices; making the region hold its own broadcast outcome; a request-time send next to `recordAudit` (the sweep's ten-minute lag is accepted for owner notices). The founder should confirm two readings: the quota notice replaces the sent report when anything parked, and send-now broadcasts get the sent report too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
