### PR TITLE
Dashboard prices print a bare $ in every locale

### DIFF
--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -117,14 +117,18 @@ export function formatDurationShort(ms: number): string {
   return `${trimFixed(ms / 86_400_000, 1)} d`;
 }
 
-/** Cents as US dollars ("$20", "$0.30"): whole dollars drop the decimals. */
+/** Cents as US dollars with a bare "$" in every locale ("$20", "$0.30", pt-BR "$0,30"
+    rather than "US$ 0,30"): whole dollars drop the decimals. */
 export function formatUsd(cents: number, locale: string): string {
   return new Intl.NumberFormat(locale, {
     style: "currency",
     currency: "USD",
     minimumFractionDigits: cents % 100 === 0 ? 0 : 2,
     maximumFractionDigits: 2,
-  }).format(cents / 100);
+  })
+    .formatToParts(cents / 100)
+    .map((part) => (part.type === "currency" ? "$" : part.type === "literal" ? "" : part.value))
+    .join("");
 }
 
 /** Payload size label ("512 B", "12.4 KB", "1.2 MB"): 1024-based, trailing zeros trimmed. */


### PR DESCRIPTION
pt-BR rendered plan prices and overage rates through Intl as "US$ 20" / "US$ 0,30". Product decision (same as millionsend-lp#10): the symbol is "$" regardless of language, digits and decimals stay locale-formatted, so the billing page reads "$20", "$330", "$0,30".

- `formatUsd` in `apps/web/src/lib/format.ts` (the one shared USD formatter; callers are the billing page's plan cards, overage copy and the over-quota estimate) builds from `formatToParts`, replacing the currency part with "$" and dropping the locale's symbol spacing.
- en output unchanged. No catalog carried a "US$" literal.

Verified: biome clean, `tsc --noEmit` for apps/web, `vitest run billing format` (40 tests green). Does not touch `billing-view.tsx`, so it composes with #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N38qEFf1k1U2P5hkPpHq7m