### PR TITLE
Reconcile reads subscriptions in two steps so Stripe's expansion limit holds

### DIFF
--- a/packages/billing/src/subscription.ts
+++ b/packages/billing/src/subscription.ts
@@ -166,14 +166,17 @@ export async function reconcileTeamPlan(deps: BillingDeps, teamId: string): Prom
   const customerId = team.stripeCustomerId;
   await deps.db.transaction(async (tx) => {
     await lockCustomer(tx as unknown as Db, customerId);
+    // A list expands from `data.`, one level deeper than a retrieve, and
+    // Stripe allows four: the list only names the newest subscription and
+    // the retrieve carries the expansions.
     const { data } = await deps.stripe.subscriptions.list({
       customer: customerId,
       status: "all",
       limit: 1,
-      expand: SUBSCRIPTION_EXPAND.map((path) => `data.${path}`),
     });
-    const sub = data[0];
-    if (!sub) return;
+    const id = data[0]?.id;
+    if (!id) return;
+    const sub = await deps.stripe.subscriptions.retrieve(id, { expand: SUBSCRIPTION_EXPAND });
     await applySubscription(tx as unknown as Db, sub, deps.log ?? console.warn, deps.stripe);
   });
 }

--- a/packages/billing/test/webhook.test.ts
+++ b/packages/billing/test/webhook.test.ts
@@ -508,9 +508,12 @@ describe("reconcileTeamPlan", () => {
       "millionsend_scale_500k_monthly",
     );
     await reconcileTeamPlan(deps(), teamId);
-    expect(state.listParams?.expand).toEqual([
-      "data.items.data.price.product",
-      "data.schedule.phases.items.price",
+    // Expansions ride on the retrieve: a list nests them one level deeper than Stripe allows.
+    expect(state.listParams?.expand).toBeUndefined();
+    expect(state.retrieves).toContain("sub_new");
+    expect(state.retrieveParams?.expand).toEqual([
+      "items.data.price.product",
+      "schedule.phases.items.price",
     ]);
     expect(await team(teamId)).toMatchObject({
       plan: "scale",


### PR DESCRIPTION
## What
`reconcileTeamPlan` listed the customer's newest subscription with the expansions prefixed by `data.`, which nests them five levels deep (`data.items.data.price.product`, `data.schedule.phases.items.price`). Stripe stops at four, so on the first production boot of v0.6.63 the reconcile failed for every team ("You cannot expand more than 4 levels of a property") and no metered item was attached. The webhook path retrieves one subscription with four levels and was fine, which is why the sandbox run never hit it.

The reconcile now lists only the id and retrieves the subscription with the usual expansions inside the same customer lock. One extra request per team per day.

## Verification
Billing (59), worker (224) and web suites pass; the reconcile test now asserts the bare list and the expanded retrieve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
