### PR TITLE
Legacy move resolves the rung through the expanded product

### DIFF
--- a/packages/billing/src/provision.ts
+++ b/packages/billing/src/provision.ts
@@ -258,9 +258,12 @@ async function moveLegacySubscriptions(
   overagePrices: Record<string, string>,
   log: (line: string) => void,
 ): Promise<string[]> {
+  // A pre-ladder price carries no rung of its own: it resolves through its
+  // product's plan metadata, so the product comes expanded.
   const { data: legacy } = await stripe.prices.list({
     lookup_keys: LEGACY_PRICE_LOOKUP_KEYS,
     limit: 10,
+    expand: ["data.product"],
   });
   const moved: string[] = [];
   for (const price of legacy) {

--- a/packages/billing/test/provision.test.ts
+++ b/packages/billing/test/provision.test.ts
@@ -75,7 +75,15 @@ function fakeStripe() {
       async list(p) {
         state.calls.push("prices.list");
         const keys = p.lookup_keys ?? [];
-        return list(state.prices.filter((x) => keys.includes(x.lookup_key ?? "")));
+        const rows = state.prices.filter((x) => keys.includes(x.lookup_key ?? ""));
+        // Like Stripe, the product is an id unless the list asks for it.
+        if (!p.expand?.includes("data.product")) return list(rows);
+        return list(
+          rows.map((x) => ({
+            ...x,
+            product: state.products.find((pr) => pr.id === x.product) ?? x.product,
+          })),
+        );
       },
       async create(p) {
         state.calls.push("prices.create");
@@ -472,8 +480,9 @@ describe("--move-legacy", () => {
         recurring: { interval: "month" },
         lookup_key: "millionsend_scale_monthly",
       }));
-    // The fake's product lookup resolves the rung through the product's metadata.
-    (legacy as { product: unknown }).product = product;
+    // The rung resolves through the product's metadata, which only an
+    // expanded list carries; the stored price keeps the id, like Stripe.
+    expect(legacy.product).toBe(product.id);
     const sub = seedSubscription(legacy);
     const first = await provision(stripe, { moveLegacy: true, log: () => {} });
     expect(first.moved).toEqual([sub.id]);


### PR DESCRIPTION
## What
`provision --move-legacy` listed the two pre-ladder prices without expanding their product. Those prices carry no rung metadata and their lookup keys are not rung keys, so the rung resolves only through the product's `millionsend_plan` metadata, which a bare list returns as an id. On the live run every legacy price logged "no rung resolves from it; skipped" and nothing moved. The test passed because it patched the product object onto the fake's stored price.

The list now expands `data.product`, and the fake returns the product object only when asked, like Stripe, so the test covers the expansion.

## Verification
Billing tests (59), tsc and biome pass. Runs from a checkout; no deploy needed — pull main and rerun `provision --move-legacy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
